### PR TITLE
Parse evaluation warnings and display in separate section.

### DIFF
--- a/buildbot_nix/__init__.py
+++ b/buildbot_nix/__init__.py
@@ -159,7 +159,7 @@ class NixEvalCommand(buildstep.ShellMixin, steps.BuildStep):
         kwargs = self.setupShellMixin(kwargs)
         super().__init__(**kwargs)
         self.project = project
-        self.observer = logobserver.BufferLogObserver()
+        self.observer = logobserver.BufferLogObserver(wantStderr=True)
         self.addLogObserver("stdio", self.observer)
         self.supported_systems = supported_systems
 
@@ -172,6 +172,11 @@ class NixEvalCommand(buildstep.ShellMixin, steps.BuildStep):
         # if the command passes extract the list of stages
         result = cmd.results()
         if result == util.SUCCESS:
+            log.info(self.observer.getStderr())
+            self.addHTMLLog(
+                "Evaluation Warnings", f"<pre>{self.observer.getStderr()}</pre>"
+            )
+
             # create a ShellCommand for each stage and add them to the build
             jobs = []
 


### PR DESCRIPTION
A live version can be seen [here](https://buildbot.redalder.org/#/builders/7/builds/52) and in case my buildbot dies or gets reset, a screenshot:

![image](https://github.com/nix-community/buildbot-nix/assets/8005463/7aa1e472-26f7-48ed-83ca-15f6e1de462b)

Possibly fixes #172, for anything more fancy we'll need #173, what do you think @zimbatm?

And due to the exploration here, I've learned that we can add arbitrary HTML to the page, as long as it is contained in one of those tabs. Well, injecting javascript and modifying the page is an option, but a really bad one :)