### PR TITLE
Added simple attic watch store example

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,15 @@ Buildbot-nix also supports pushing packages to cachix. Check out the comment out
 [example configuration](https://github.com/Mic92/buildbot-nix/blob/main/examples/master.nix)
 in our repository.
 
+#### Attic
+
+Buildbot-nix does not have native support for pushing packages to
+[attic](https://github.com/zhaofengli/attic) yet. However it's possible to
+integrate run a systemd service as described in
+[this example configuration](./examples/attic-watch-store.nix). The systemd
+service watches for changes in the local buildbot-nix store and uploads the
+contents to the attic cache.
+
 ## Real-World Deployments
 
 See Buildbot-nix in action in these deployments:

--- a/examples/attic-watch-store.nix
+++ b/examples/attic-watch-store.nix
@@ -1,0 +1,35 @@
+{ pkgs
+, config
+, inputs
+, ...
+}: {
+  # sops-nix (https://github.com/Mic92/sops-nix) is just an example, here.
+  # Replace with your own secret management as needed: https://wiki.nixos.org/wiki/Comparison_of_secret_managing_schemes
+  sops.secrets."attic/prod-auth-token" = { sopsFile = ../secrets.yaml; };
+  sops.secrets."attic/netrc-file-pull-push" = { sopsFile = ../secrets.yaml; };
+
+  # Add netrc file for this machine to do its normal thing with the cache, as a machine.
+  nix.settings.netrc-file = config.sops.secrets."attic/netrc-file-pull-push".path;
+
+  systemd.services.attic-watch-store = {
+    wantedBy = [ "multi-user.target" ];
+    after = [ "network-online.target" ];
+    environment.HOME = "/var/lib/attic-watch-store";
+    serviceConfig = {
+      DynamicUser = true;
+      MemoryHigh = "5%";
+      MemoryMax = "10%";
+      LoadCredential = "prod-auth-token:${config.sops.secrets."attic/prod-auth-token".path}";
+      StateDirectory = "attic-watch-store";
+    };
+    path = [ pkgs.attic-client ];
+    script = ''
+      set -eux -o pipefail
+      ATTIC_TOKEN=$(< $CREDENTIALS_DIRECTORY/prod-auth-token)
+      # Replace https://cache.<domain> with your own cache URL.
+      attic login prod https://cache.<domain> $ATTIC_TOKEN
+      attic use prod
+      exec attic watch-store prod:prod
+    '';
+  };
+}       


### PR DESCRIPTION
This is a simple but working systemd service to upload the contents of the local buildbox-nix store to an attic cache, for use my other machines/nodes.