### PR TITLE
Fix JWT token renewal condition

### DIFF
--- a/buildbot_nix/github/jwt_token.py
+++ b/buildbot_nix/github/jwt_token.py
@@ -73,7 +73,7 @@ class JWTToken(RepoToken):
         # return list(map(lambda installation: create_installation_access_token(installation['id']).json()["token"], installations))
 
     def get(self) -> str:
-        if datetime.now(tz=UTC) - self.expiration > self.lifetime * 0.8:
+        if self.expiration - datetime.now(tz=UTC) < self.lifetime * 0.2:
             self.token, self.expiration = JWTToken.generate_token(
                 self.app_id, self.app_private_key, self.lifetime
             )


### PR DESCRIPTION
Fixes #184, tested by running the following script for 8 hours and creating 360 builds over two repos:
```bash
#!/usr/bin/env bash

set -x -e -o pipefail

for repo in *; do
  [ -d "$repo" ] && (
    cd "$repo"

    git config --local user.name 'test'
    git config --local user.email 'test@example.com'
    git commit --allow-empty --m 'test'
    GIT_SSH_COMMAND='ssh -F/dev/null -i .git/id_ed25519 -o IdentitiesOnly=yes' git push origin
  )
done
```