### PR TITLE
Combined build reports GitHub

### DIFF
--- a/buildbot_nix/__init__.py
+++ b/buildbot_nix/__init__.py
@@ -533,7 +533,7 @@ def nix_build_config(
             updateSourceStamp=False,
             doStepIf=do_register_gcroot_if,
             copy_properties=["out_path", "attr"],
-            set_properties={"report_status": False}
+            set_properties={"report_status": False},
         ),
     )
     factory.addStep(
@@ -598,7 +598,7 @@ def nix_skipped_build_config(
             updateSourceStamp=False,
             doStepIf=do_register_gcroot_if,
             copy_properties=["out_path", "attr"],
-            set_properties={"report_status": False}
+            set_properties={"report_status": False},
         ),
     )
     return util.BuilderConfig(
@@ -642,6 +642,7 @@ def nix_register_gcroot_config(
         env={},
         factory=factory,
     )
+
 
 def nix_build_combined_config(
     project: GitProject,

--- a/buildbot_nix/__init__.py
+++ b/buildbot_nix/__init__.py
@@ -908,7 +908,7 @@ class NixConfigurator(ConfiguratorBase):
             backends["github"] = GithubBackend(self.config.github, self.config.url)
 
         if self.config.gitea is not None:
-            backends["gitea"] = GiteaBackend(self.config.gitea)
+            backends["gitea"] = GiteaBackend(self.config.gitea, self.config.url)
 
         auth: AuthBase | None = (
             backends[self.config.auth_backend].create_auth()

--- a/buildbot_nix/__init__.py
+++ b/buildbot_nix/__init__.py
@@ -533,6 +533,7 @@ def nix_build_config(
             updateSourceStamp=False,
             doStepIf=do_register_gcroot_if,
             copy_properties=["out_path", "attr"],
+            set_properties={"report_status": False}
         ),
     )
     factory.addStep(
@@ -597,6 +598,7 @@ def nix_skipped_build_config(
             updateSourceStamp=False,
             doStepIf=do_register_gcroot_if,
             copy_properties=["out_path", "attr"],
+            set_properties={"report_status": False}
         ),
     )
     return util.BuilderConfig(

--- a/buildbot_nix/common.py
+++ b/buildbot_nix/common.py
@@ -180,4 +180,3 @@ def filter_for_combined_builds(reports: Any) -> Any | None:
     if "report_status" in properties and not properties["report_status"][0]:
         return None
     return reports
-

--- a/buildbot_nix/common.py
+++ b/buildbot_nix/common.py
@@ -172,3 +172,12 @@ def model_validate_project_cache(cls: type[_T], project_cache_file: Path) -> lis
 
 def model_dump_project_cache(repos: list[_T]) -> str:
     return json.dumps([repo.model_dump() for repo in repos])
+
+
+def filter_for_combined_builds(reports: Any) -> Any | None:
+    properties = reports[0]["builds"][0]["properties"]
+
+    if "report_status" in properties and not properties["report_status"][0]:
+        return None
+    return reports
+

--- a/buildbot_nix/gitea_projects.py
+++ b/buildbot_nix/gitea_projects.py
@@ -1,7 +1,8 @@
 import os
 import signal
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 from urllib.parse import urlparse
 
 from buildbot.config.builder import BuilderConfig
@@ -13,9 +14,9 @@ from buildbot.www.avatar import AvatarBase
 from buildbot_gitea.auth import GiteaAuth  # type: ignore[import]
 from buildbot_gitea.reporter import GiteaStatusPush  # type: ignore[import]
 from pydantic import BaseModel
+from twisted.internet import defer
 from twisted.logger import Logger
 from twisted.python import log
-from twisted.internet import defer
 
 from .common import (
     ThreadDeferredBuildStep,
@@ -106,13 +107,22 @@ class GiteaProject(GitProject):
         # TODO Gitea doesn't include this information
         return False  # self.data["owner"]["type"] == "Organization"
 
+
 class ModifyingGiteaStatusPush(GiteaStatusPush):
-    def checkConfig(self, modifyingFilter: Callable[[Any], Any | None] = lambda x: x, **kwargs: Any) -> Any:
+    def checkConfig(
+        self,
+        modifyingFilter: Callable[[Any], Any | None] = lambda x: x,  # noqa: N803
+        **kwargs: Any,
+    ) -> Any:
         self.modifyingFilter = modifyingFilter
 
         return super().checkConfig(**kwargs)
 
-    def reconfigService(self, modifyingFilter: Callable[[Any], Any | None] = lambda x: x, **kwargs: Any) -> Any:
+    def reconfigService(
+        self,
+        modifyingFilter: Callable[[Any], Any | None] = lambda x: x,  # noqa: N803
+        **kwargs: Any,
+    ) -> Any:
         self.modifyingFilter = modifyingFilter
 
         return super().reconfigService(**kwargs)

--- a/buildbot_nix/github_projects.py
+++ b/buildbot_nix/github_projects.py
@@ -25,6 +25,7 @@ from twisted.internet import defer
 from .common import (
     ThreadDeferredBuildStep,
     atomic_write_file,
+    filter_for_combined_builds,
     filter_repos_by_topic,
     http_request,
     model_dump_project_cache,
@@ -330,13 +331,6 @@ class ModifyingGitHubStatusPush(GitHubStatusPush):
         result = yield super().sendMessage(reports)
         return result
 
-def filter_for_combined_builds(reports: Any) -> Any | None:
-    properties = reports[0]["builds"][0]["properties"]
-
-    if "report_status" in properties and not properties["report_status"][0]:
-        return None
-    return reports
-
 class GithubLegacyAuthBackend(GithubAuthBackend):
     auth_type: GitHubLegacyConfig
 
@@ -443,6 +437,7 @@ class GithubAppAuthBackend(GithubAuthBackend):
             return self.installation_tokens[
                 self.project_id_map[props["projectname"]]
             ].get()
+
 
         return ModifyingGitHubStatusPush(
             token=WithProperties("%(github_token)s", github_token=get_github_token),

--- a/buildbot_nix/models.py
+++ b/buildbot_nix/models.py
@@ -179,6 +179,7 @@ class BuildbotNixConfig(BaseModel):
     outputs_path: Path | None
     url: str
     post_build_steps: list[PostBuildStep]
+    job_report_limit: int | None
 
     @property
     def nix_workers_secret(self) -> str:

--- a/nix/master.nix
+++ b/nix/master.nix
@@ -340,10 +340,10 @@ in
       };
 
       jobReportLimit = lib.mkOption {
-        type = lib.types.nullOr lib.types.ints.positive;
+        type = lib.types.nullOr lib.types.ints.unsigned;
         description = ''
           The max number of build jobs per `nix-eval` `buildbot-nix` will report to backends (GitHub, Gitea, etc.).
-          If set to `null`, report everything, if set to `n` (some positive intereger), report builds individually
+          If set to `null`, report everything, if set to `n` (some unsiggned intereger), report builds individually
           as long as the number of builds is less than or equal to `n`, then report builds using a combined
           `nix-build-combined` build.
         '';

--- a/nix/master.nix
+++ b/nix/master.nix
@@ -338,6 +338,17 @@ in
         default = null;
         example = "/var/www/buildbot/nix-outputs";
       };
+
+      jobReportLimit = lib.mkOption {
+        type = lib.types.nullOr lib.types.ints.positive;
+        description = ''
+          The max number of build jobs per `nix-eval` `buildbot-nix` will report to backends (GitHub, Gitea, etc.).
+          If set to `null`, report everything, if set to `n` (some positive intereger), report builds individually
+          as long as the number of builds is less than or equal to `n`, then report builds using a combined
+          `nix-build-combined` build.
+        '';
+        default = 50;
+      };
     };
   };
   config = lib.mkMerge [
@@ -469,6 +480,7 @@ in
                 outputs_path = cfg.outputsPath;
                 url = config.services.buildbot-nix.master.webhookBaseUrl;
                 post_build_steps = cfg.postBuildSteps;
+                job_report_limit=if cfg.jobReportLimit == null then "None" else builtins.toJSON cfg.jobReportLimit;
               }}").read_text()))
             )
           ''

--- a/nix/master.nix
+++ b/nix/master.nix
@@ -482,7 +482,9 @@ in
         dbUrl = config.services.buildbot-nix.master.dbUrl;
 
         package = cfg.buildbotNixpkgs.buildbot.overrideAttrs (old: {
-          patches = old.patches ++ [ ./0001-master-reporters-github-render-token-for-each-reques.patch ];
+          patches = old.patches ++ [
+            ./0001-master-reporters-github-render-token-for-each-reques.patch
+          ];
         });
         pythonPackages =
           let


### PR DESCRIPTION
This PR adds two derived classes `ModifyingGitHubStatusPush` and `ModifyingGiteaStatusPush`, which take the `modifyingFilter` argument. It has the type `Callable[[Any], Any | None]`, if it returns `None` the report is canceled, if it returns non `None` the returned object is used instead of the original.

We use this addition to implement "combined builds", if the jobs count for a `nix-eval` is over a certain number (made to be configurable in a future rendition of this PR) `buildbot-nix` will not create reports on GitHub for each build, but only a single `nix-build-combined` report which indicates whether all builds succeeded or failed.

~~This PR is also a draft because it is built for buildbot 3, as with #216 I first need to bump my instance to 4. I'll make a separate patch for 3 and 4 so we keep compatibility.~~

### TODO 
- ~implement for Gitea~
- ~make the limit configurable.~
- `nix-build-combined` appears only after all builds complete