### PR TITLE
Register gcroots for PRs

### DIFF
--- a/nix/0001-GiteaHandler-set-the-category-of-PR-changes-to-pull-.patch
+++ b/nix/0001-GiteaHandler-set-the-category-of-PR-changes-to-pull-.patch
@@ -1,0 +1,27 @@
+From 0cab84b1a8b27b097a980fb6a4de09001eec79dc Mon Sep 17 00:00:00 2001
+From: magic_rb <richard@brezak.sk>
+Date: Mon, 15 Jul 2024 15:58:50 +0200
+Subject: [PATCH] `GiteaHandler` set the category of PR changes to "pull",
+ match `GitHubHandler`
+
+Signed-off-by: magic_rb <richard@brezak.sk>
+---
+ buildbot_gitea/webhook.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/buildbot_gitea/webhook.py b/buildbot_gitea/webhook.py
+index 444f20e..468365c 100644
+--- a/buildbot_gitea/webhook.py
++++ b/buildbot_gitea/webhook.py
+@@ -103,7 +103,7 @@ class GiteaHandler(BaseHookHandler):
+             'revlink': pull_request['html_url'],
+             'repository': head['repo']['ssh_url'],
+             'project': repository['full_name'],
+-            'category': event_type,
++            'category': "pull",
+             'properties': {
+                 'event': event_type,
+                 'base_branch': base['ref'],
+-- 
+2.44.1
+

--- a/nix/0002-GiteaHandler-set-branch-to-the-PR-branch-not-the-bas.patch
+++ b/nix/0002-GiteaHandler-set-branch-to-the-PR-branch-not-the-bas.patch
@@ -1,0 +1,30 @@
+From 7be1b81102e71617ddc568f7957ccc1429f0513d Mon Sep 17 00:00:00 2001
+From: magic_rb <richard@brezak.sk>
+Date: Mon, 15 Jul 2024 15:44:15 +0200
+Subject: [PATCH 2/3] `GiteaHandler`, set `branch` to the PR branch not the
+ base
+
+Signed-off-by: magic_rb <richard@brezak.sk>
+---
+ buildbot_gitea/webhook.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/buildbot_gitea/webhook.py b/buildbot_gitea/webhook.py
+index a63cfad..17d4809 100644
+--- a/buildbot_gitea/webhook.py
++++ b/buildbot_gitea/webhook.py
+@@ -97,9 +97,9 @@ class GiteaHandler(BaseHookHandler):
+                 pull_request['number'],
+                 pull_request['title'],
+                 pull_request['body']),
+-            'revision': base['sha'],
++            'revision': head['sha'],
+             'when_timestamp': timestamp,
+-            'branch': base['ref'],
++            'branch': head['ref'],
+             'revlink': pull_request['html_url'],
+             'repository': base['repo']['ssh_url'],
+             'project': repository['full_name'],
+-- 
+2.44.1
+


### PR DESCRIPTION
~Very WIP, problem is that I tried to execute the registering in the skipped builder in the master, which needed the gcroots directory to be writable by both. the master and workers. But POSIX file permissions had a different idea and ruined my evening. I'll have to trigger the registration on a different builder...~

Works by adding a new builder, `project-nix-register-gcroot` which is triggered from both the `project-nix-build` and `project-nix-skipped-build` builders. That allows to always run the gcroot creation on the workers and avoids any permission issues. To keep `nix-skipped-build` performant, the check whether to do gcroot registration or not is done using OS primitives and is not done in a separate worker or buildstep.