### PR TITLE
fix cachix

### DIFF
--- a/buildbot_nix/models.py
+++ b/buildbot_nix/models.py
@@ -69,7 +69,7 @@ class CachixConfig(BaseModel):
         return environment
 
     class Config:
-        fields = exclude_fields(["singing_key", "auth_token"])
+        fields = exclude_fields(["signing_key", "auth_token"])
 
 
 class GiteaConfig(BaseModel):

--- a/examples/master.nix
+++ b/examples/master.nix
@@ -62,10 +62,11 @@
 
     # optional cachix
     #cachix = {
+    #  enabled = true;
     #  name = "my-cachix";
     #  # One of the following is required:
-    #  signingKeyFile = "/var/lib/secrets/cachix-key";
-    #  authTokenFile = "/var/lib/secrets/cachix-token";
+    #  auth.signingKey.file = "/var/lib/secrets/cachix-key";
+    #  auth.authToken.file = "/var/lib/secrets/cachix-token";
     #};
   };
 

--- a/nix/checks/master.nix
+++ b/nix/checks/master.nix
@@ -36,5 +36,6 @@
     start_all()
     # wait for our service to start
     node1.wait_for_unit("buildbot-master")
+    node1.wait_until_succeeds("curl --fail -s --head localhost:8010", timeout=60)
   '';
 }

--- a/nix/checks/master.nix
+++ b/nix/checks/master.nix
@@ -23,6 +23,11 @@
             oauthSecretFile = pkgs.writeText "oauthSecret" "ffffffffffffffffffffffffffffffffffffffff";
             oauthId = "aaaaaaaaaaaaaaaaaaaa";
           };
+          cachix = {
+            enable = true;
+            name = "my-cachix";
+            auth.authToken.file = pkgs.writeText "cachixAuthToken" "00000000000000000000";
+          };
         };
       };
   };


### PR DESCRIPTION
I think this is might be fixed but I'll test it in a couple of hours to make sure.

```
❯ nix eval .#nixosConfigurations.example-cachix-master-worker-combined-x86_64-linux.config.systemd.services.buildbot-master.serviceConfig.LoadCredential
[ "buildbot-nix-workers:/nix/store/zjhcahczn8b64kw90bbxzhlvw5smm0vi-workers.json" "github-webhook-secret:/nix/store/svaxdh1zss9jgs7365s601gxprg633jv-webhookSecret" "github-app-secret-key:/nix/store/z3yssjnmvpp3vfbyr7i7r8f3qfqgydc1-app-secret.key" "github-oauth-secret:/nix/store/jbvsw789q8g1a23cc9qvq5jhf14mf8v2-oauthSecret" ]
```
```
❯ nix eval .#nixosConfigurations.example-cachix-master-worker-combined-x86_64-linux.config.systemd.services.buildbot-master.serviceConfig.LoadCredential
[ "buildbot-nix-workers:/nix/store/zjhcahczn8b64kw90bbxzhlvw5smm0vi-workers.json" "github-webhook-secret:/nix/store/svaxdh1zss9jgs7365s601gxprg633jv-webhookSecret" "github-app-secret-key:/nix/store/z3yssjnmvpp3vfbyr7i7r8f3qfqgydc1-app-secret.key" "github-oauth-secret:/nix/store/jbvsw789q8g1a23cc9qvq5jhf14mf8v2-oauthSecret" "cachix-auth-token:/var/lib/secrets/cachix-token" ]
```