### PR TITLE
chore(treefmt): Replace root file

### DIFF
--- a/nix/treefmt/flake-module.nix
+++ b/nix/treefmt/flake-module.nix
@@ -4,7 +4,7 @@
   ];
   perSystem = { pkgs, ... }: {
     treefmt = {
-      projectRootFile = ".git/config";
+      projectRootFile = "flake.nix";
       programs.nixpkgs-fmt.enable = true;
       programs.shellcheck.enable = true;
       programs.deno.enable = true;


### PR DESCRIPTION
.git/config won't be present when using a VCS such as [jujutsu](https://github.com/martinvonz/jj), however there will always be exactly 1 flake.nix at the root of the repository so we can use it instead

(an example of this being used is also in the treefmt README in the flakes section: https://github.com/numtide/treefmt-nix?tab=readme-ov-file#flakes)