### PR TITLE
Use installation tokens for GitHub change hooks

### DIFF
--- a/nix/master.nix
+++ b/nix/master.nix
@@ -584,7 +584,14 @@ in
         dbUrl = config.services.buildbot-nix.master.dbUrl;
 
         package = cfg.buildbotNixpkgs.buildbot.overrideAttrs (old: {
-          patches = old.patches ++ [ ./0001-master-reporters-github-render-token-for-each-reques.patch ];
+          patches = old.patches ++ [
+            ./0001-master-reporters-github-render-token-for-each-reques.patch
+            (pkgs.fetchpatch {
+              name = "give-access-to-full-name-in-the-git-hub-hook-properties.patch";
+              url = "https://github.com/buildbot/buildbot/commit/27eb8c311c0beeb35c9b0c21be437684744dce21.patch";
+              hash = "sha256-VPH7EoDVZXwx6oc6rzkUcsNEq+nGLcTNmNMlrrW6Mog=";
+            })
+          ];
         });
         pythonPackages =
           let


### PR DESCRIPTION
This should fix handling PRs, as reported by @Mic92:
```
Failed fetching PR commit message: response code 401: b'{"message":"Bad credentials","documentation_url":"[https://docs.github.com/rest","status":"401](https://docs.github.com/rest%22,%22status%22:%22401)"}'
```