### PR TITLE
Support fully private mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,19 @@ examples to guide you:
 
 ### Authentication backend
 
-At the moment all projects are visible without authentication.
+At the moment `buildbot-nix` offers two access modes, `public` and
+`fullyPrivate`. `public` is the default and gives read-only access to all of
+buildbot, including builds, logs and builders. For read-write access,
+authentication is still needed, this is controlled by the `authBackend` option.
+
+`fullyPrivate` will hide buildbot behind `oauth2-proxy` which protects the whole
+buildbot instance. buildbot fetches the currently authenticated user from
+`oauth2-proxy` so the same admin, organisation rules apply.
+
+`fullyPrivate` acccess mode is a workaround as buildbot does not support hiding
+information natively as now.
+
+#### Public
 
 For some actions a login is required. This login can either be based on GitHub
 or on Gitea (more logins may follow). The backend is set by the
@@ -92,9 +104,9 @@ We have the following two roles:
   - All member of the organisation where this repository is located
   - They can restart builds
 
-### Integration with GitHub
+##### Integration with GitHub
 
-#### GitHub App
+###### GitHub App
 
 This is the preferred option to setup buildbot-nix for GitHub.
 
@@ -128,7 +140,7 @@ To integrate with GitHub using app authentication:
    changes (new repositories or installations) automatically, it is therefore
    necessary to manually trigger a reload or wait for the next periodic reload.
 
-#### Token Auth
+###### Token Auth
 
 To integrate with GitHub using legacy token authentication:
 
@@ -136,7 +148,7 @@ To integrate with GitHub using legacy token authentication:
    permissions. For GitHub organizations, it's advisable to create a separate
    GitHub user for managing repository webhooks.
 
-### Optional when using GitHub login
+##### Optional when using GitHub login
 
 1. **GitHub App**: Set up a GitHub app for Buildbot to enable GitHub user
    authentication on the Buildbot dashboard. (can be the same as for GitHub App
@@ -149,7 +161,7 @@ Afterwards add the configured github topic to every project that should build
 with buildbot-nix. Notice that the buildbot user needs to have admin access to
 this repository because it needs to install a webhook.
 
-### Integration with Gitea
+##### Integration with Gitea
 
 To integrate with Gitea
 
@@ -170,6 +182,22 @@ Afterwards add the configured gitea topic to every project that should build
 with buildbot-nix. Notice that the buildbot user needs to have repository write
 access to this repository because it needs to install a webhook in the
 repository.
+
+#### Fully Private
+
+To enable fully private mode, set `acessMode.fullyPrivate` to an attrset
+containing the required options for fully private use, refer to the examples and
+module implementation (`nix/master.nix`).
+
+This access mode honors the `admins` option in addition to the
+`accessMode.fullyPrivate.organisations` option. To allow access from certain
+organisations, you must explicitly list them.
+
+If you've set `authBackend` previously, unset it, or you will get an error about
+a conflicting definitions. `fullyPrivate` requires the `authBackend` to be set
+to `basichttpauth` to function (this is handled by the module, which is why you
+can leave it unset). For a concrete example please refer to
+[fully-private-github](./examples/fully-private-github.nix)
 
 ## Binary caches
 

--- a/buildbot_nix/__init__.py
+++ b/buildbot_nix/__init__.py
@@ -20,12 +20,11 @@ from buildbot.process.results import ALL_RESULTS, statusToString
 from buildbot.secrets.providers.file import SecretInAFile
 from buildbot.steps.trigger import Trigger
 from buildbot.www.authz import Authz
-from buildbot.www.auth import UserPasswordAuth
 from buildbot.www.authz.endpointmatchers import EndpointMatcherBase, Match
 
 if TYPE_CHECKING:
     from buildbot.process.log import StreamLog
-    from buildbot.www.auth import AuthBase, UserInfoProviderBase
+    from buildbot.www.auth import AuthBase
 
 from twisted.internet import defer
 from twisted.logger import Logger
@@ -37,9 +36,9 @@ from .gitea_projects import GiteaBackend
 from .github_projects import (
     GithubBackend,
 )
-from .models import BuildbotNixConfig, AuthBackendConfig
-from .projects import GitBackend, GitProject
+from .models import AuthBackendConfig, BuildbotNixConfig
 from .oauth2_proxy_auth import OAuth2ProxyAuth
+from .projects import GitBackend, GitProject
 
 SKIPPED_BUILDER_NAME = "skipped-builds"
 

--- a/buildbot_nix/models.py
+++ b/buildbot_nix/models.py
@@ -18,6 +18,7 @@ def exclude_fields(fields: list[str]) -> dict[str, dict[str, bool]]:
 class AuthBackendConfig(str, Enum):
     github = "github"
     gitea = "gitea"
+    httpbasicauth = "httpbasicauth"
     none = "none"
 
 
@@ -180,7 +181,14 @@ class BuildbotNixConfig(BaseModel):
     url: str
     post_build_steps: list[PostBuildStep]
     job_report_limit: int | None
+    http_basic_auth_password_file: Path | None
 
     @property
     def nix_workers_secret(self) -> str:
         return read_secret_file(self.nix_workers_secret_file)
+
+    @property
+    def http_basic_auth_password(self) -> str:
+        if self.http_basic_auth_password_file is None:
+            raise InternalError
+        return read_secret_file(self.http_basic_auth_password_file)

--- a/buildbot_nix/oauth2_proxy_auth.py
+++ b/buildbot_nix/oauth2_proxy_auth.py
@@ -19,7 +19,7 @@ log = Logger()
 class OAuth2ProxyAuth(AuthBase):
     header: ClassVar[bytes] = b"Authorization"
     prefix: ClassVar[bytes] = b"Basic "
-    user_info_provider: UserInfoProviderBase
+    user_info_provider: UserInfoProviderBase = None
     password: bytes
 
     def __init__(self, password: str, **kwargs: Any) -> None:

--- a/buildbot_nix/oauth2_proxy_auth.py
+++ b/buildbot_nix/oauth2_proxy_auth.py
@@ -1,0 +1,68 @@
+import base64
+import typing
+from typing import Any, ClassVar
+
+from buildbot.util import bytes2unicode, unicode2bytes
+from buildbot.www.auth import AuthBase, UserInfoProviderBase
+from twisted.internet import defer
+from twisted.internet.defer import Generator
+from twisted.logger import Logger
+from twisted.web.error import Error
+from twisted.web.pages import forbidden
+from twisted.web.resource import IResource
+from twisted.web.server import Request
+from twisted.web.util import Redirect
+
+log = Logger()
+
+
+class OAuth2ProxyAuth(AuthBase):
+    header: ClassVar[bytes] = b"Authorization"
+    prefix: ClassVar[bytes] = b"Basic "
+    user_info_provider: UserInfoProviderBase
+    password: bytes
+
+    def __init__(self, password: str, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        if self.user_info_provider is None:
+            self.user_info_provider = UserInfoProviderBase()
+        self.password = unicode2bytes(password)
+
+    def getLoginResource(self) -> IResource:  # noqa: N802
+        return forbidden(message="URL is not supported for authentication")
+
+    def getLogoutResource(self) -> IResource:  # noqa: N802
+        return typing.cast(IResource, Redirect(b"/oauth2/sign_out"))
+
+    @defer.inlineCallbacks
+    def maybeAutoLogin(  # noqa: N802
+        self, request: Request
+    ) -> Generator[defer.Deferred[None], object, None]:
+        header = request.getHeader(self.header)
+        if header is None:
+            msg = (
+                b"missing http header "
+                + self.header
+                + b". Check your oauth2-proxy config!"
+            )
+            raise Error(403, msg)
+        if not header.startswith(self.prefix):
+            msg = (
+                b"invalid http header "
+                + self.header
+                + b". Check your oauth2-proxy config!"
+            )
+            raise Error(403, msg)
+        header = header.removeprefix(self.prefix)
+        (username, password) = base64.b64decode(header).split(b":")
+        username = bytes2unicode(username)
+
+        if password != self.password:
+            msg = b"invalid password given. Check your oauth2-proxy config!!"
+            raise Error(403, msg)
+
+        session = request.getSession()  # type: ignore[no-untyped-call]
+        user_info = {"username": username}
+        if session.user_info != user_info:
+            session.user_info = user_info
+            yield self.updateUserInfo(request)

--- a/examples/default.nix
+++ b/examples/default.nix
@@ -65,4 +65,14 @@ in
       { services.buildbot-nix.worker.masterUrl = ''tcp:host=2a09\:80c0\:102\:\:1:port=9989''; }
     ];
   };
+
+  "example-oauth2-proxy-github-${system}" = nixosSystem {
+    inherit system;
+    modules = [
+      dummy
+      buildbot-nix.nixosModules.buildbot-master
+      buildbot-nix.nixosModules.buildbot-worker
+      ./fully-private-github.nix
+    ];
+  };
 }

--- a/examples/fully-private-github.nix
+++ b/examples/fully-private-github.nix
@@ -1,0 +1,53 @@
+{ pkgs, ... }:
+{
+  # For a more full fledged and commented example refer to ./master.nix and ./worker.nix,
+  # those two files give a better introductory example than this one
+  services.buildbot-nix.master = {
+    enable = true;
+
+    domain = "buildbot.example.org";
+    workersFile = pkgs.writeText "workers.json" "changeMe";
+    admins = [ ];
+
+    # `authBackend` can be omitted here, the module sets it itself
+    authBackend = "httpbasicauth";
+    # this is a randomly generated secret, which is only used to authenticate requests
+    # from the oauth2 proxy to buildbot
+    httpBasicAuthPasswordFile = pkgs.writeText "http-basic-auth-passwd" "changeMe";
+
+    gitea = {
+      enable = true;
+      tokenFile = "/secret/gitea_token";
+      instanceUrl = "https://codeberg.org";
+      webhookSecretFile = pkgs.writeText "webhook-secret" "changeMe";
+      topic = "build-with-buildbot";
+    };
+    github = {
+      enable = true;
+      webhookSecretFile = pkgs.writeText "github_webhook_secret" "changeMe";
+      topic = "build-with-buildbot";
+      authType.app = {
+        secretKeyFile = pkgs.writeText "github_app_secret_key" "changeMe";
+        id = 0;
+      };
+    };
+
+    # optional nix-eval-jobs settings
+    evalWorkerCount = 2; # limit number of concurrent evaluations
+    evalMaxMemorySize = 4096; # limit memory usage per evaluation
+
+    accessMode.fullyPrivate = {
+      backend = "github";
+      # this is a randomly generated alphanumeric secret, which is used to encrypt the cookies set by
+      # oauth2-proxy, it must be 8, 16, or 32 characters long
+      cookieSecretFile = pkgs.writeText "github_cookie_secret" "changeMe";
+      clientSecretFile = pkgs.writeText "github_oauth_secret" "changeMe";
+      clientId = "Iv1.XXXXXXXXXXXXXXXX";
+    };
+  };
+
+  services.buildbot-nix.worker = {
+    enable = true;
+    workerPasswordFile = "/secret/worker_secret";
+  };
+}

--- a/nix/master.nix
+++ b/nix/master.nix
@@ -813,7 +813,7 @@ in
               "gitea"
             ])
             {
-              github-user = lib.concatStringsSep "," cfg.admins;
+              github-user = lib.concatStringsSep "," (cfg.accessMode.fullyPrivate.users ++ cfg.admins);
               github-team = cfg.accessMode.fullyPrivate.teams;
               email-domain = "*";
             }

--- a/nix/master.nix
+++ b/nix/master.nix
@@ -185,10 +185,12 @@ in
       };
 
       accessMode = lib.mkOption {
-        default = { public = {}; };
+        default = {
+          public = { };
+        };
         type = lib.types.attrTag {
           public = lib.mkOption {
-            type = lib.types.submodule {};
+            type = lib.types.submodule { };
             description = ''
               Default public mode, will allow read only access to anonymous users. Authentication is handled by
               one of the `authBackend's. CAUTION this will leak information about private repos, the instance has
@@ -233,7 +235,7 @@ in
                   description = ''
                     A list of teams that should be given access to BuildBot.
                   '';
-                  default = [];
+                  default = [ ];
                 };
 
                 users = lib.mkOption {
@@ -241,7 +243,7 @@ in
                   description = ''
                     A list of users that should be given access to BuildBot.
                   '';
-                  default = [];
+                  default = [ ];
                 };
 
                 port = lib.mkOption {
@@ -777,7 +779,9 @@ in
           # Allow buildbot-master to write to this directory
           "d ${cfg.outputsPath} 0755 buildbot buildbot - -";
 
-      services.buildbot-nix.master.authBackend = lib.mkIf (cfg.accessMode ? "fullyPrivate") "httpbasicauth";
+      services.buildbot-nix.master.authBackend = lib.mkIf (
+        cfg.accessMode ? "fullyPrivate"
+      ) "httpbasicauth";
 
       services.oauth2-proxy = lib.mkIf (cfg.accessMode ? "fullyPrivate") {
         enable = true;
@@ -797,17 +801,19 @@ in
 
             cookie-secure = true;
           }
-          (lib.mkIf (cfg.authBackend == "httpbasicauth") {
-            set-basic-auth = true;
-          })
-          (lib.mkIf (lib.elem cfg.accessMode.fullyPrivate.backend [ "github" "gitea" ]) {
-            github-user = lib.concatStringsSep "," cfg.admins;
-            github-team = cfg.accessMode.fullyPrivate.teams;
-            email-domain = "*";
-          })
-          (lib.mkIf (cfg.accessMode.fullyPrivate.backend == "github") {
-            provider = "github";
-          })
+          (lib.mkIf (cfg.authBackend == "httpbasicauth") { set-basic-auth = true; })
+          (lib.mkIf
+            (lib.elem cfg.accessMode.fullyPrivate.backend [
+              "github"
+              "gitea"
+            ])
+            {
+              github-user = lib.concatStringsSep "," cfg.admins;
+              github-team = cfg.accessMode.fullyPrivate.teams;
+              email-domain = "*";
+            }
+          )
+          (lib.mkIf (cfg.accessMode.fullyPrivate.backend == "github") { provider = "github"; })
           (lib.mkIf (cfg.accessMode.fullyPrivate.backend == "gitea") {
             provider = "github";
             provider-display-name = "Gitea";
@@ -817,7 +823,6 @@ in
           })
         ];
       };
-
 
       systemd.services.oauth2-proxy = lib.mkIf (cfg.accessMode ? "fullyPrivate") {
         serviceConfig = {

--- a/nix/master.nix
+++ b/nix/master.nix
@@ -822,9 +822,9 @@ in
           (lib.mkIf (cfg.accessMode.fullyPrivate.backend == "gitea") {
             provider = "github";
             provider-display-name = "Gitea";
-            login-url = "https://${cfg.gitea.instanceUrl}/login/oauth/authorize";
-            redeem-url = "https://${cfg.gitea.instanceUrl}/login/oauth/access_token";
-            validate-url = "https://${cfg.gitea.instanceUrl}/api/v1/user/emails";
+            login-url = "${cfg.gitea.instanceUrl}/login/oauth/authorize";
+            redeem-url = "${cfg.gitea.instanceUrl}/login/oauth/access_token";
+            validate-url = "${cfg.gitea.instanceUrl}/api/v1/user/emails";
           })
         ];
       };

--- a/nix/master.nix
+++ b/nix/master.nix
@@ -800,6 +800,11 @@ in
             upstream = "http://127.0.0.1:${builtins.toString config.services.buildbot-master.port}";
 
             cookie-secure = true;
+            skip-auth-route = [ "^/change_hook" ];
+            api-route = [
+              "^/api"
+              "^/ws$"
+            ];
           }
           (lib.mkIf (cfg.authBackend == "httpbasicauth") { set-basic-auth = true; })
           (lib.mkIf


### PR DESCRIPTION
This places `oauth2-proxy` in front of buildbot and protects the whole instance unconditionally. Buildbot doesn't really support hiding information currently, the websocket is completely unauthenticated and leaks information left and right, therefore a proxy is necessary.

# TODO
- [x] use HTTP basic auth to auth the oauth2 proxy against buildbot and prevent other programs which may have access to `127.0.0.1` from bypassing the oauth proxy.