### PR TITLE
Always report `nix-build`, even with individual build reports

### DIFF
--- a/buildbot_nix/__init__.py
+++ b/buildbot_nix/__init__.py
@@ -405,10 +405,9 @@ class BuildTrigger(buildstep.ShellMixin, steps.BuildStep):
         reports. The reporting is based on custom events and logic, see `BuildNixEvalStatusGenerator` for
         the receiving side.
         """
-        if self.combine_builds:
-            self.produce_event_for_build_by_id(
-                "started-nix-build", self.build.buildid, None
-            )
+        self.produce_event_for_build_by_id(
+            "started-nix-build", self.build.buildid, None
+        )
 
         done: list[BuildTrigger.DoneJob] = []
         scheduled: list[BuildTrigger.ScheduledJob] = []
@@ -565,10 +564,9 @@ class BuildTrigger(buildstep.ShellMixin, steps.BuildStep):
                 f"\t- new result: {util.Results[overall_result].upper()} \n"
             )
 
-        if self.combine_builds:
-            self.produce_event_for_build_by_id(
-                "finished-nix-build", self.build.buildid, overall_result
-            )
+        self.produce_event_for_build_by_id(
+            "finished-nix-build", self.build.buildid, overall_result
+        )
         scheduler_log.addStdout("Done!\n")
         return overall_result
 


### PR DESCRIPTION
Always reports the combined `nix-build` build report, even with individual builds, closes #279, see image:
![image](https://github.com/user-attachments/assets/b64ce662-ad5d-4df5-aa79-3c4405e64002)
