### PR TITLE
Remember first failed build URL and display it in cached failures

### DIFF
--- a/buildbot_nix/__init__.py
+++ b/buildbot_nix/__init__.py
@@ -207,8 +207,7 @@ class BuildTrigger(buildstep.ShellMixin, steps.BuildStep):
         props = BuildTrigger.set_common_properties(
             Properties(), self.project, source, job
         )
-        props.setProperty("first_failure", str(first_failure), source)
-        props.setProperty("first_failure_url", first_failure_url, source)
+        props.setProperty("first_failure_url", first_failure.url, source)
 
         return (self.cached_failure_scheduler, props)
 
@@ -483,7 +482,7 @@ class BuildTrigger(buildstep.ShellMixin, steps.BuildStep):
                 elif failed_build is not None and self.build.reason != "rebuild":
                     scheduler_log.addStdout(
                         f"\t- skipping {build.attr} due to cached failure, first failed at {failed_build.time}\n"
-                        + f"\t  see build at {failed_build.url}\n"
+                        f"\t  see build at {failed_build.url}\n"
                     )
                     build_schedule_order.remove(build)
 
@@ -747,11 +746,10 @@ class CachedFailureStep(steps.BuildStep):
         error_log: StreamLog = yield self.addLog("nix_error")
         msg = [
             f"{attr} was failed because it has failed previously and its failure has been cached.",
-            f"  first failure time: {self.getProperty('first_failure')}",
         ]
         url = self.getProperty("first_failure_url")
         if url:
-            msg.append(f"  first failure url: {url}")
+            msg.append(f"  failed build: {url}")
         error_log.addStderr("\n".join(msg) + "\n")
         return util.FAILURE
 

--- a/buildbot_nix/__init__.py
+++ b/buildbot_nix/__init__.py
@@ -1,3 +1,4 @@
+import atexit
 import copy
 import dataclasses
 import graphlib
@@ -40,7 +41,8 @@ from twisted.internet import defer
 from twisted.logger import Logger
 from twisted.python.failure import Failure
 
-from . import failed_builds, models
+from . import models
+from .failed_builds import FailedBuild, FailedBuildDB
 from .gitea_projects import GiteaBackend
 from .github_projects import (
     GithubBackend,
@@ -86,6 +88,7 @@ class BuildTrigger(buildstep.ShellMixin, steps.BuildStep):
     wait_for_finish_deferred: defer.Deferred[tuple[list[int], int]] | None
     brids: list[int]
     consumers: dict[int, Any]
+    failed_builds_db: FailedBuildDB
 
     @dataclass
     class ScheduledJob:
@@ -118,6 +121,7 @@ class BuildTrigger(buildstep.ShellMixin, steps.BuildStep):
         successful_jobs: list[NixEvalJobSuccess],
         failed_jobs: list[NixEvalJobError],
         combine_builds: bool,
+        failed_builds_db: FailedBuildDB,
         **kwargs: Any,
     ) -> None:
         self.project = project
@@ -130,6 +134,7 @@ class BuildTrigger(buildstep.ShellMixin, steps.BuildStep):
         self.failed_eval_scheduler = failed_eval_scheduler
         self.cached_failure_scheduler = cached_failure_scheduler
         self.dependency_failed_scheduler = dependency_failed_scheduler
+        self.failed_builds_db = failed_builds_db
         self._result_list: list[int] = []
         self.ended = False
         self.running = False
@@ -193,7 +198,9 @@ class BuildTrigger(buildstep.ShellMixin, steps.BuildStep):
         return (self.failed_eval_scheduler, props)
 
     def schedule_cached_failure(
-        self, job: NixEvalJobSuccess, first_failure: datetime, first_failure_url: str,
+        self,
+        job: NixEvalJobSuccess,
+        first_failure: FailedBuild,
     ) -> tuple[str, Properties]:
         source = "nix-eval-nix"
 
@@ -470,7 +477,7 @@ class BuildTrigger(buildstep.ShellMixin, steps.BuildStep):
             # check which jobs should be scheduled now
             schedule_now = []
             for build in list(build_schedule_order):
-                failed_build = failed_builds.check_build(build.drvPath)
+                failed_build = self.failed_builds_db.check_build(build.drvPath)
                 if job_closures.get(build.drvPath):
                     pass
                 elif failed_build is not None and self.build.reason != "rebuild":
@@ -482,14 +489,14 @@ class BuildTrigger(buildstep.ShellMixin, steps.BuildStep):
 
                     brids, results_deferred = yield self.schedule(
                         ss_for_trigger,
-                        *self.schedule_cached_failure(build, failed_build.time, failed_build.url),
+                        *self.schedule_cached_failure(build, failed_build),
                     )
                     scheduled.append(
                         BuildTrigger.ScheduledJob(build, brids, results_deferred)
                     )
                     self.brids.extend(brids.values())
                 elif failed_build is not None and self.build.reason == "rebuild":
-                    failed_builds.remove_build(build.drvPath)
+                    self.failed_builds_db.remove_build(build.drvPath)
                     scheduler_log.addStdout(
                         f"\t- not skipping {build.attr} with cached failure due to rebuild, first failed at {failed_build.time}\n"
                     )
@@ -545,9 +552,14 @@ class BuildTrigger(buildstep.ShellMixin, steps.BuildStep):
             # if it failed, remove all dependent jobs, schedule placeholders and add them to the list of scheduled jobs
             if isinstance(job, NixEvalJobSuccess):
                 if result != SUCCESS:
-                    if self.build.reason == "rebuild" or not failed_builds.check_build(job.drvPath):
-                      url = yield self.build.getUrl()
-                      failed_builds.add_build(job.drvPath, datetime.now(tz=UTC), url)
+                    if (
+                        self.build.reason == "rebuild"
+                        or not self.failed_builds_db.check_build(job.drvPath)
+                    ):
+                        url = yield self.build.getUrl()
+                        self.failed_builds_db.add_build(
+                            job.drvPath, datetime.now(tz=UTC), url
+                        )
 
                     removed = self.get_failed_dependents(
                         job, build_schedule_order, job_closures
@@ -611,6 +623,7 @@ class NixEvalCommand(buildstep.ShellMixin, steps.BuildStep):
         project: GitProject,
         supported_systems: list[str],
         job_report_limit: int | None,
+        failed_builds_db: FailedBuildDB,
         **kwargs: Any,
     ) -> None:
         kwargs = self.setupShellMixin(kwargs)
@@ -620,6 +633,7 @@ class NixEvalCommand(buildstep.ShellMixin, steps.BuildStep):
         self.addLogObserver("stdio", self.observer)
         self.supported_systems = supported_systems
         self.job_report_limit = job_report_limit
+        self.failed_builds_db = failed_builds_db
 
     @defer.inlineCallbacks
     def produce_event(
@@ -687,6 +701,7 @@ class NixEvalCommand(buildstep.ShellMixin, steps.BuildStep):
                             self.job_report_limit is not None
                             and self.number_of_jobs > self.job_report_limit
                         ),
+                        failed_builds_db=self.failed_builds_db,
                     ),
                 ]
             )
@@ -861,6 +876,7 @@ def nix_eval_config(
     worker_count: int,
     max_memory_size: int,
     job_report_limit: int | None,
+    failed_builds_db: FailedBuildDB,
 ) -> BuilderConfig:
     """Uses nix-eval-jobs to evaluate hydraJobs from flake.nix in parallel.
     For each evaluated attribute a new build pipeline is started.
@@ -887,6 +903,7 @@ def nix_eval_config(
             name="evaluate flake",
             supported_systems=supported_systems,
             job_report_limit=job_report_limit,
+            failed_builds_db=failed_builds_db,
             command=[
                 "nix-eval-jobs",
                 "--workers",
@@ -1170,6 +1187,7 @@ def config_for_project(
     eval_lock: MasterLock,
     post_build_steps: list[steps.BuildStep],
     job_report_limit: int | None,
+    failed_builds_db: FailedBuildDB,
     outputs_path: Path | None = None,
 ) -> None:
     config["projects"].append(Project(project.name))
@@ -1258,6 +1276,7 @@ def config_for_project(
                 worker_count=nix_eval_worker_count,
                 max_memory_size=nix_eval_max_memory_size,
                 eval_lock=eval_lock,
+                failed_builds_db=failed_builds_db,
             ),
             nix_build_config(
                 project,
@@ -1464,6 +1483,10 @@ class NixConfigurator(ConfiguratorBase):
                 )
             )
 
+        db = FailedBuildDB(Path("failed_builds.dbm"))
+        # Hacky but we have no other hooks just now to run code on shutdown.
+        atexit.register(lambda: db.close())
+
         for project in projects:
             config_for_project(
                 config,
@@ -1475,7 +1498,8 @@ class NixConfigurator(ConfiguratorBase):
                 eval_lock,
                 [x.to_buildstep() for x in self.config.post_build_steps],
                 self.config.job_report_limit,
-                self.config.outputs_path,
+                failed_builds_db=db,
+                outputs_path=self.config.outputs_path,
             )
 
         config["workers"].append(worker.LocalWorker(SKIPPED_BUILDER_NAME))
@@ -1533,5 +1557,3 @@ class NixConfigurator(ConfiguratorBase):
                 backends=list(backends.values()),
                 projects=projects,
             )
-
-        failed_builds.initialize_database(Path("failed_builds.dbm"))

--- a/buildbot_nix/__init__.py
+++ b/buildbot_nix/__init__.py
@@ -730,16 +730,14 @@ class CachedFailureStep(steps.BuildStep):
         attr = self.getProperty("attr")
         # show eval error
         error_log: StreamLog = yield self.addLog("nix_error")
-        error_log.addStderr(
-            "\n".join(
-                [
-                    f"{attr} was failed because it has failed previously and its failure has been cached.",
-                    f"  first failure time: {self.getProperty('first_failure')}",
-                    f"  first failure url: {self.getProperty('first_failure_url')}",
-                ]
-            )
-            + "\n"
-        )
+        msg = [
+            f"{attr} was failed because it has failed previously and its failure has been cached.",
+            f"  first failure time: {self.getProperty('first_failure')}",
+        ]
+        url = self.getProperty("first_failure_url")
+        if url:
+            msg.append(f"  first failure url: {url}")
+        error_log.addStderr("\n".join(msg) + "\n")
         return util.FAILURE
 
 

--- a/buildbot_nix/failed_builds.py
+++ b/buildbot_nix/failed_builds.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 if TYPE_CHECKING:
     database: None | dbm._Database = None
@@ -18,6 +18,7 @@ class FailedBuildsError(Exception):
 class FailedBuild(BaseModel):
     derivation: str
     time: datetime
+    url: str = Field(default="unknown")
 
 
 DB_NOT_INIT_MSG = "Database not initialized"
@@ -30,12 +31,12 @@ def initialize_database(db_path: Path) -> None:
         database = dbm.open(str(db_path), "c")
 
 
-def add_build(derivation: str, time: datetime) -> None:
+def add_build(derivation: str, time: datetime, url: str) -> None:
     global database  # noqa: PLW0602
 
     if database is not None:
         database[derivation] = FailedBuild(
-            derivation=derivation, time=time
+            derivation=derivation, time=time, url=url
         ).model_dump_json()
     else:
         raise FailedBuildsError(DB_NOT_INIT_MSG)

--- a/buildbot_nix/failed_builds.py
+++ b/buildbot_nix/failed_builds.py
@@ -1,14 +1,8 @@
 import dbm
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
-
-if TYPE_CHECKING:
-    database: None | dbm._Database = None
-else:
-    database: Any = None
 
 
 class FailedBuildsError(Exception):
@@ -18,45 +12,28 @@ class FailedBuildsError(Exception):
 class FailedBuild(BaseModel):
     derivation: str
     time: datetime
-    url: str = Field(default="unknown")
+    url: str = Field(
+        default=f"build unknown. Please delete {Path("failed_builds.dbm").resolve()} to get a build url"
+    )
 
 
-DB_NOT_INIT_MSG = "Database not initialized"
+class FailedBuildDB:
+    def __init__(self, db_path: Path) -> None:
+        self.database = dbm.open(str(db_path), "c")
 
+    def close(self) -> None:
+        self.database.close()
 
-def initialize_database(db_path: Path) -> None:
-    global database  # noqa: PLW0603
-
-    if not database:
-        database = dbm.open(str(db_path), "c")
-
-
-def add_build(derivation: str, time: datetime, url: str) -> None:
-    global database  # noqa: PLW0602
-
-    if database is not None:
-        database[derivation] = FailedBuild(
+    def add_build(self, derivation: str, time: datetime, url: str) -> None:
+        self.database[derivation] = FailedBuild(
             derivation=derivation, time=time, url=url
         ).model_dump_json()
-    else:
-        raise FailedBuildsError(DB_NOT_INIT_MSG)
 
-
-def check_build(derivation: str) -> FailedBuild | None:
-    global database  # noqa: PLW0602
-
-    if database is not None:
-        if derivation in database:
+    def check_build(self, derivation: str) -> FailedBuild | None:
+        if derivation in self.database:
             # TODO create dummy if deser fails?
-            return FailedBuild.model_validate_json(database[derivation])
+            return FailedBuild.model_validate_json(self.database[derivation])
         return None
-    raise FailedBuildsError(DB_NOT_INIT_MSG)
 
-
-def remove_build(derivation: str) -> None:
-    global database  # noqa: PLW0602
-
-    if database is not None:
-        del database[derivation]
-    else:
-        raise FailedBuildsError(DB_NOT_INIT_MSG)
+    def remove_build(self, derivation: str) -> None:
+        del self.database[derivation]


### PR DESCRIPTION
Closes #280, currently a draft because it doesn't yet output a clickable link, it merely just dumps a link into the textual output of the cached failed build, see image:
![image](https://github.com/user-attachments/assets/a3a95c1c-9f19-4d54-8aef-23c8be201513)

Next I will attempt to add a clickable link using HTML.