### PR TITLE
feat!: Update output path writing

### DIFF
--- a/buildbot_nix/__init__.py
+++ b/buildbot_nix/__init__.py
@@ -768,16 +768,54 @@ class UpdateBuildOutput(steps.BuildStep):
         self.project = project
         self.path = path
 
+    def join_traversalsafe(self, root: Path, joined: Path) -> Path:
+        root = root.resolve()
+
+        for part in joined.parts:
+            new_root = (root / part).resolve()
+
+            if not new_root.is_relative_to(root):
+                msg = f"Joined path attempted to traverse upwards when processing {root} against {part} (gave {new_root})"
+                raise ValueError(msg)
+
+            root = new_root
+
+        return root
+
+    def join_all_traversalsafe(self, root: Path, *paths: Path) -> Path:
+        for path in paths:
+            root = self.join_traversalsafe(root, path)
+
+        return root
+
+    @defer.inlineCallbacks
     def run(self) -> Generator[Any, object, Any]:
         props = self.build.getProperties()
         if props.getProperty("branch") != self.project.default_branch:
             return util.SKIPPED
 
-        attr = Path(props.getProperty("attr")).name
         out_path = props.getProperty("out_path")
-        # XXX don't hardcode this
-        self.path.mkdir(parents=True, exist_ok=True)
-        (self.path / attr).write_text(out_path)
+
+        if not out_path:  # if, e.g., the build fails and doesn't produce an output
+            return util.SKIPPED
+
+        project_name = Path(props.getProperty("projectname"))
+
+        target = Path(props.getProperty("branch"))
+
+        attr = Path(props.getProperty("attr")).name
+
+        try:
+            file = self.join_all_traversalsafe(self.path, project_name, target, attr)
+        except ValueError as e:
+            error_log: StreamLog = yield self.addLog("path_error")
+            error_log.addStderr(f"Path traversal prevented ... skipping update: {e}")
+            return util.FAILURE
+
+        file.parent.mkdir(parents=True, exist_ok=True)
+
+        file.write_text(out_path)
+
         return util.SUCCESS
 
 
@@ -1086,6 +1124,7 @@ def nix_cached_failure_config(
 def nix_skipped_build_config(
     project: GitProject,
     worker_names: list[str],
+    outputs_path: Path | None = None,
 ) -> BuilderConfig:
     """Dummy builder that is triggered when a build is skipped."""
     factory = util.BuildFactory()
@@ -1114,6 +1153,14 @@ def nix_skipped_build_config(
             set_properties={"report_status": False},
         ),
     )
+    if outputs_path is not None:
+        factory.addStep(
+            UpdateBuildOutput(
+                project=project,
+                name="Update build output",
+                path=outputs_path,
+            ),
+        )
     return util.BuilderConfig(
         name=f"{project.name}/nix-skipped-build",
         project=project.name,
@@ -1262,7 +1309,7 @@ def config_for_project(
                 outputs_path=outputs_path,
                 post_build_steps=post_build_steps,
             ),
-            nix_skipped_build_config(project, [SKIPPED_BUILDER_NAME]),
+            nix_skipped_build_config(project, [SKIPPED_BUILDER_NAME], outputs_path),
             nix_failed_eval_config(project, [SKIPPED_BUILDER_NAME]),
             nix_dependency_failed_config(project, [SKIPPED_BUILDER_NAME]),
             nix_cached_failure_config(project, [SKIPPED_BUILDER_NAME]),


### PR DESCRIPTION
3dbf4d9da7e1d99ce2adf72f156ba6c2aedc699b with this diff:

```diff
diff --git a/buildbot_nix/__init__.py b/buildbot_nix/__init__.py
index 0145fbf..890a31c 100644
--- a/buildbot_nix/__init__.py
+++ b/buildbot_nix/__init__.py
@@ -791,10 +791,7 @@ class UpdateBuildOutput(steps.BuildStep):
     @defer.inlineCallbacks
     def run(self) -> Generator[Any, object, Any]:
         props = self.build.getProperties()
-
-        pr = props.getProperty("pr_number")
-
-        if not pr and props.getProperty("branch") != self.project.default_branch:
+        props.getProperty("branch") != self.project.default_branch:
             return util.SKIPPED

         out_path = props.getProperty("out_path")
@@ -804,9 +801,9 @@ class UpdateBuildOutput(steps.BuildStep):

         project_name = Path(props.getProperty("projectname"))

-        target = Path(f"pulls/{pr}") if pr else Path(props.getProperty("branch"))
+        target = Path(props.getProperty("branch"))

-        attr = Path(props.getProperty("attr"))
+        attr = Path(props.getProperty("attr")).name

         try:
             file = self.join_all_traversalsafe(self.path, project_name, target, attr)
```