### PR TITLE
Secrets for hercules-ci style effects

### DIFF
--- a/buildbot_effects/__init__.py
+++ b/buildbot_effects/__init__.py
@@ -223,6 +223,7 @@ def run_effects(
         secrets = secrets.copy()
         secrets["hercules-ci"] = {"data": {"token": "dummy"}}
         tmp.write(json.dumps(secrets).encode())
+        tmp.flush()
         bubblewrap_cmd.extend(
             [
                 "--ro-bind",

--- a/buildbot_nix/models.py
+++ b/buildbot_nix/models.py
@@ -191,6 +191,7 @@ class BuildbotNixConfig(BaseModel):
     post_build_steps: list[PostBuildStep]
     job_report_limit: int | None
     http_basic_auth_password_file: Path | None
+    effects_per_repo_secrets: dict[str, str]
 
     @property
     def nix_workers_secret(self) -> str:

--- a/nix/buildbot-effects.nix
+++ b/nix/buildbot-effects.nix
@@ -1,4 +1,10 @@
-{ lib, python3, bubblewrap, setuptools, buildPythonApplication }:
+{
+  lib,
+  python3,
+  bubblewrap,
+  setuptools,
+  buildPythonApplication,
+}:
 buildPythonApplication {
   name = "buildbot-effects";
   format = "pyproject";

--- a/nix/checks/effects.nix
+++ b/nix/checks/effects.nix
@@ -2,11 +2,13 @@
   name = "effects";
   nodes = {
     # `self` here is set by using specialArgs in `lib.nix`
-    node1 = { self, pkgs, ... }: {
-      environment.systemPackages = [
-        (pkgs.python3.pkgs.callPackage ../../nix/buildbot-effects.nix { })
-      ];
-    };
+    node1 =
+      { self, pkgs, ... }:
+      {
+        environment.systemPackages = [
+          (pkgs.python3.pkgs.callPackage ../../nix/buildbot-effects.nix { })
+        ];
+      };
   };
   testScript = ''
     start_all()

--- a/nix/master.nix
+++ b/nix/master.nix
@@ -26,6 +26,19 @@ let
     else
       builtins.toJSON value;
 
+  cleanUpRepoName =
+    name:
+    builtins.replaceStrings
+      [
+        "/"
+        ":"
+      ]
+      [
+        "_slash_"
+        "_colon_"
+      ]
+      name;
+
   backendPort =
     if (cfg.accessMode ? "fullyPrivate") then
       cfg.accessMode.fullyPrivate.port
@@ -492,6 +505,13 @@ in
         '';
         default = 50;
       };
+
+      effects.perRepoSecretFiles = lib.mkOption {
+        type = lib.types.attrsOf lib.types.path;
+        description = "Per-repository secrets files for buildbot effects. The attribute name is of the form \"github:owner/repo\". The secrets themselves need to be valid JSON files.";
+        default = { };
+        example = ''{ "github:nix-community/buildbot-nix" = config.agenix.secrets.buildbot-nix-effects-secrets.path; }'';
+      };
     };
   };
   config = lib.mkMerge [
@@ -659,6 +679,10 @@ in
                   post_build_steps = cfg.postBuildSteps;
                   job_report_limit = cfg.jobReportLimit;
                   http_basic_auth_password_file = cfg.httpBasicAuthPasswordFile;
+                  effects_per_repo_secrets = lib.mapAttrs' (name: _path: {
+                    inherit name;
+                    value = "effects-secret__${cleanUpRepoName name}";
+                  }) cfg.effects.perRepoSecretFiles;
                 }
               }").read_text()))
             )
@@ -740,7 +764,10 @@ in
             ++ lib.optionals cfg.gitea.enable [
               "gitea-token:${cfg.gitea.tokenFile}"
               "gitea-webhook-secret:${cfg.gitea.webhookSecretFile}"
-            ];
+            ]
+            ++ (lib.mapAttrsToList (
+              repoName: path: "effects-secret__${cleanUpRepoName repoName}:${path}"
+            ) cfg.effects.perRepoSecretFiles);
           RuntimeDirectory = "buildbot-master";
         };
       };


### PR DESCRIPTION
This PR to another PR (sorry for the complexity) is what I use currently to build and deploy my flake-based personal system configuration. This holds all the changes I had to make to get `flyctl deploy` working for docker images built in my flake:

* Add `/var/tmp` as a tmpfs mount point in the bwrapped effects runner
* Flush at the end of writing secrets.json before passing it to `bwrap` (otherwise that file would be empty, thanks python buffering).
* Make per-repo secrets configurable and pass those through from the nix config to the buildbot master plugin, to each worker, and pick that up in the buildbot_effects commandline invocation.

With these changes, I have successfully run a flyctl deploy with the access token sourced from secrets passed in on that per-repo basis.