### PR TITLE
Add aarch64-darwin to systems the flake cares about

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
         ] ++ inputs.nixpkgs.lib.optional (inputs.treefmt-nix ? flakeModule) ./nix/treefmt/flake-module.nix;
         systems = [
           "x86_64-linux"
+          "aarch64-linux"
           "aarch64-darwin"
         ];
         flake = {

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,10 @@
         imports = [
           ./nix/checks/flake-module.nix
         ] ++ inputs.nixpkgs.lib.optional (inputs.treefmt-nix ? flakeModule) ./nix/treefmt/flake-module.nix;
-        systems = [ "x86_64-linux" ];
+        systems = [
+          "x86_64-linux"
+          "aarch64-darwin"
+        ];
         flake = {
           nixosModules.buildbot-master.imports = [
             ./nix/master.nix

--- a/flake.nix
+++ b/flake.nix
@@ -87,7 +87,7 @@
               let
                 nixosMachines = lib.mapAttrs' (
                   name: config: lib.nameValuePair "nixos-${name}" config.config.system.build.toplevel
-                ) ((lib.filterAttrs (_: config: config.pkgs.system == system)) self.nixosConfigurations);
+                ) ((lib.filterAttrs (name: _: lib.hasSuffix system name)) self.nixosConfigurations);
                 packages = lib.mapAttrs' (n: lib.nameValuePair "package-${n}") self'.packages;
                 devShells = lib.mapAttrs' (n: lib.nameValuePair "devShell-${n}") self'.devShells;
               in

--- a/nix/checks/flake-module.nix
+++ b/nix/checks/flake-module.nix
@@ -1,7 +1,7 @@
 { self, ... }:
 {
   perSystem =
-    { pkgs, ... }:
+    { pkgs, lib, ... }:
     {
       checks =
         let
@@ -10,7 +10,7 @@
             inherit self pkgs;
           };
         in
-        {
+        lib.mkIf (pkgs.hostPlatform.isLinux) {
           master = import ./master.nix checkArgs;
           worker = import ./worker.nix checkArgs;
         };


### PR DESCRIPTION
This enables the dev shell & corresponding dev tools on recent macs, which happens to be the machine type I'm using (-: