### PR TITLE
Actually enable `mypy`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 result
+result-*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/buildbot_nix/__init__.py
+++ b/buildbot_nix/__init__.py
@@ -36,7 +36,7 @@ from buildbot.www.authz import Authz
 from buildbot.www.authz.endpointmatchers import EndpointMatcherBase, Match
 
 if TYPE_CHECKING:
-    from buildbot.process.log import Log, StreamLog
+    from buildbot.process.log import StreamLog
     from buildbot.www.auth import AuthBase
 
 from twisted.internet import defer

--- a/buildbot_nix/__init__.py
+++ b/buildbot_nix/__init__.py
@@ -1437,7 +1437,7 @@ class AnyProjectEndpointMatcher(EndpointMatcherBase):
         epobject: Any,
         epdict: dict[str, Any],
         options: dict[str, Any],
-    ) -> Match:
+    ) -> Match | None:
         return await self.check_builder(epobject, epdict, "build")
 
     async def match_BuildRequestEndpoint_stop(  # noqa: N802
@@ -1445,7 +1445,7 @@ class AnyProjectEndpointMatcher(EndpointMatcherBase):
         epobject: Any,
         epdict: dict[str, Any],
         options: dict[str, Any],
-    ) -> Match:
+    ) -> Match | None:
         return await self.check_builder(epobject, epdict, "buildrequest")
 
 

--- a/buildbot_nix/github_projects.py
+++ b/buildbot_nix/github_projects.py
@@ -365,10 +365,10 @@ class GithubLegacyAuthBackend(GithubAuthBackend):
 
 
 class GitHubLegacySecretService(SecretProviderBase):
-    name = "GitHubLegacySecretService"
+    name: str | None = "GitHubLegacySecretService" # type: ignore
     token: LegacyToken
 
-    def reconfigService(self, token: LegacyToken) -> None:
+    def reconfigService(self, token: LegacyToken) -> None: # type: ignore
         self.token = token
 
     def get(self, entry: str) -> str | None:
@@ -458,11 +458,11 @@ class GithubAppAuthBackend(GithubAuthBackend):
 
 
 class GitHubAppSecretService(SecretProviderBase):
-    name = "GitHubAppSecretService"
+    name: str | None = "GitHubAppSecretService"  # type: ignore
     installation_tokens: dict[int, InstallationToken]
     jwt_token: JWTToken
 
-    def reconfigService(
+    def reconfigService( # type: ignore
         self, installation_tokens: dict[int, InstallationToken], jwt_token: JWTToken
     ) -> None:
         self.installation_tokens = installation_tokens

--- a/buildbot_nix/github_projects.py
+++ b/buildbot_nix/github_projects.py
@@ -365,10 +365,10 @@ class GithubLegacyAuthBackend(GithubAuthBackend):
 
 
 class GitHubLegacySecretService(SecretProviderBase):
-    name: str | None = "GitHubLegacySecretService" # type: ignore
+    name: str | None = "GitHubLegacySecretService"  # type: ignore[assignment]
     token: LegacyToken
 
-    def reconfigService(self, token: LegacyToken) -> None: # type: ignore
+    def reconfigService(self, token: LegacyToken) -> None:  # type: ignore[override]
         self.token = token
 
     def get(self, entry: str) -> str | None:
@@ -458,11 +458,11 @@ class GithubAppAuthBackend(GithubAuthBackend):
 
 
 class GitHubAppSecretService(SecretProviderBase):
-    name: str | None = "GitHubAppSecretService"  # type: ignore
+    name: str | None = "GitHubAppSecretService"  # type: ignore[assignment]
     installation_tokens: dict[int, InstallationToken]
     jwt_token: JWTToken
 
-    def reconfigService( # type: ignore
+    def reconfigService(  # type: ignore[override]
         self, installation_tokens: dict[int, InstallationToken], jwt_token: JWTToken
     ) -> None:
         self.installation_tokens = installation_tokens

--- a/buildbot_nix/models.py
+++ b/buildbot_nix/models.py
@@ -230,7 +230,7 @@ class NixEvalJobSuccess(BaseModel):
 
 
 NixEvalJob = NixEvalJobError | NixEvalJobSuccess
-NixEvalJobModel = TypeAdapter(NixEvalJob)
+NixEvalJobModel: TypeAdapter[NixEvalJob] = TypeAdapter(NixEvalJob)
 
 
 class NixDerivation(BaseModel):

--- a/buildbot_nix/nix_status_generator.py
+++ b/buildbot_nix/nix_status_generator.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 from enum import Enum
 from typing import Any, ClassVar
 
-from buildbot.interfaces import IRenderable, IReportGenerator
+from buildbot.interfaces import IReportGenerator
 from buildbot.master import BuildMaster
 from buildbot.process.build import Build
 from buildbot.process.buildrequest import BuildRequest
@@ -13,10 +13,10 @@ from buildbot.process.results import CANCELLED
 from buildbot.reporters import utils
 from buildbot.reporters.base import ReporterBase
 from buildbot.reporters.generators.utils import BuildStatusGeneratorMixin
-from buildbot.reporters.message import MessageFormatterRenderable, MessageFormatterBase
+from buildbot.reporters.message import MessageFormatterBase, MessageFormatterRenderable
 from buildbot.reporters.utils import getDetailsForBuild
 from twisted.logger import Logger
-from zope.interface import implementer # type: ignore[import]
+from zope.interface import implementer  # type: ignore[import]
 
 log = Logger()
 
@@ -109,9 +109,10 @@ class BuildNixEvalStatusGenerator(BuildStatusGeneratorMixin):
             "all", tags, builders, schedulers, branches, None, add_logs, add_patch
         )
 
-        self.start_formatter = start_formatter or MessageFormatterRenderable("Build started.")
+        self.start_formatter = start_formatter or MessageFormatterRenderable(
+            "Build started."
+        )
         self.end_formatter = end_formatter or MessageFormatterRenderable("Build done.")
-
 
     # TODO: copy pasted from buildbot, make it static upstream and reuse
     @staticmethod
@@ -164,7 +165,7 @@ class BuildNixEvalStatusGenerator(BuildStatusGeneratorMixin):
         master: BuildMaster,
         reporter: ReporterBase,
         key: tuple[str, None | Any, str],
-        data: dict[str, Any], # TODO database types
+        data: dict[str, Any],  # TODO database types
     ) -> None | dict[str, Any]:
         what, _, event = key
         if what == "builds":

--- a/buildbot_nix/oauth2_proxy_auth.py
+++ b/buildbot_nix/oauth2_proxy_auth.py
@@ -17,7 +17,7 @@ log = Logger()
 class OAuth2ProxyAuth(AuthBase):
     header: ClassVar[bytes] = b"Authorization"
     prefix: ClassVar[bytes] = b"Basic "
-    user_info_provider: UserInfoProviderBase = None
+    user_info_provider: UserInfoProviderBase
     password: bytes
 
     def __init__(self, password: str, **kwargs: Any) -> None:

--- a/buildbot_nix/repo_config/__init__.py
+++ b/buildbot_nix/repo_config/__init__.py
@@ -3,9 +3,12 @@ from tomllib import TOMLDecodeError
 from typing import TYPE_CHECKING, Self
 
 from buildbot.process.buildstep import ShellMixin
+from buildbot.process.buildstep import BuildStep
 
 if TYPE_CHECKING:
-    from buildbot.process.log import Log
+    from buildbot.process.log import StreamLog
+    class BuildStepShellMixin(BuildStep, ShellMixin):
+        pass
 from pydantic import BaseModel, ValidationError
 
 
@@ -18,8 +21,8 @@ class BranchConfig(BaseModel):
     attribute: str = "checks"
 
     @classmethod
-    async def extract_during_step(cls, buildstep: ShellMixin) -> Self:
-        stdio: Log = await buildstep.addLog("stdio")
+    async def extract_during_step(cls, buildstep: BuildStepShellMixin) -> Self:
+        stdio: StreamLog = await buildstep.addLog("stdio")
         cmd = await buildstep.makeRemoteShellCommand(
             collectStdout=True,
             collectStderr=True,

--- a/buildbot_nix/repo_config/__init__.py
+++ b/buildbot_nix/repo_config/__init__.py
@@ -2,14 +2,15 @@ import tomllib
 from tomllib import TOMLDecodeError
 from typing import TYPE_CHECKING, Self
 
-from buildbot.process.buildstep import ShellMixin
-from buildbot.process.buildstep import BuildStep
+from buildbot.process.buildstep import BuildStep, ShellMixin
+from pydantic import BaseModel, ValidationError
 
 if TYPE_CHECKING:
     from buildbot.process.log import StreamLog
-    class BuildStepShellMixin(BuildStep, ShellMixin):
-        pass
-from pydantic import BaseModel, ValidationError
+
+
+class BuildStepShellMixin(BuildStep, ShellMixin):
+    pass
 
 
 class RepoConfig(BaseModel):

--- a/nix/treefmt/flake-module.nix
+++ b/nix/treefmt/flake-module.nix
@@ -19,13 +19,25 @@
 
         programs.mypy = {
           enable = pkgs.stdenv.buildPlatform.isLinux;
-          directories.".".extraPythonPackages = [
-            pkgs.buildbot
-            pkgs.buildbot-worker
-            pkgs.python3.pkgs.twisted
-          ];
+          package = pkgs.buildbot.python.pkgs.mypy;
+          directories."." = {
+            modules = [
+              "buildbot_nix"
+            ];
+            extraPythonPackages = [
+              (pkgs.python3.pkgs.toPythonModule pkgs.buildbot)
+              pkgs.buildbot-worker
+              pkgs.python3.pkgs.twisted
+              pkgs.python3.pkgs.pydantic
+              pkgs.python3.pkgs.zope-interface
+            ];
+          };
         };
 
+        # the mypy module adds `./buildbot_nix/**/*.py` which does not appear to work
+        # furthermore, saying `directories.""` will lead to `/buildbot_nix/**/*.py` which
+        # is obviously incorrect...
+        settings.formatter."mypy-.".includes = [ "buildbot_nix/**/*.py" ];
         settings.formatter.ruff-check.priority = 1;
         settings.formatter.ruff-format.priority = 2;
       };

--- a/nix/treefmt/flake-module.nix
+++ b/nix/treefmt/flake-module.nix
@@ -2,7 +2,7 @@
 {
   imports = [ inputs.treefmt-nix.flakeModule ];
   perSystem =
-    { pkgs, ... }:
+    { pkgs, lib, ... }:
     {
       treefmt = {
         projectRootFile = "LICENSE.md";
@@ -37,7 +37,9 @@
         # the mypy module adds `./buildbot_nix/**/*.py` which does not appear to work
         # furthermore, saying `directories.""` will lead to `/buildbot_nix/**/*.py` which
         # is obviously incorrect...
-        settings.formatter."mypy-.".includes = [ "buildbot_nix/**/*.py" ];
+        settings.formatter."mypy-." = lib.mkIf pkgs.stdenv.buildPlatform.isLinux {
+          includes = [ "buildbot_nix/**/*.py" ];
+        };
         settings.formatter.ruff-check.priority = 1;
         settings.formatter.ruff-format.priority = 2;
       };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,6 @@ ignore-names = [
 python_version = "3.11"
 pretty = true
 warn_redundant_casts = true
-disallow_untyped_calls = true
+disallow_untyped_calls = false
 disallow_untyped_defs = true
 no_implicit_optional = true


### PR DESCRIPTION
- [ ] some functions [1](https://github.com/nix-community/buildbot-nix/pull/331/files#diff-17cd44102ed0e7933f2157f30179888048c3beb5652a8fc4997f60183fedc427R465) [2](https://github.com/nix-community/buildbot-nix/pull/331/files#diff-17cd44102ed0e7933f2157f30179888048c3beb5652a8fc4997f60183fedc427L371) cannot be types as they don't fit into the subclass hierarchy, this is unfixable without changing the whole class hierarchy (buildbot likes this one a lot)
  ```python
  class A:
    def foo(a: int) -> int:
      return a
  class B:
    def foo(b: int, a: int) -> int: # this line will throw a type error
      return b + super().foo(a)
  ```
- [ ] `twisted.application.service.Service` [1](https://github.com/nix-community/buildbot-nix/pull/331/files#diff-17cd44102ed0e7933f2157f30179888048c3beb5652a8fc4997f60183fedc427L368) [2](https://github.com/nix-community/buildbot-nix/pull/331/files#diff-17cd44102ed0e7933f2157f30179888048c3beb5652a8fc4997f60183fedc427L461) doesn't type hint the `name` field, `mypy` assumes it has the type `None` and throws an error in `GitHubLegacySecretService` and `GitHubAppSecretService`
- [ ] `zope.interface` [1](https://github.com/nix-community/buildbot-nix/pull/331/files#diff-23f6eebd3059eac8e494796cdb5123595ff9c690e25518c08270ac48508acefbL19) doesn't have a py.typed marker and therefore will throw errors like `Skipping analyzing "zope.interface": module is installed, but missing library stubs or py.typed marker`
- [ ] `BuildNixEvalStatusGenerator.start_formatter` [1](https://github.com/nix-community/buildbot-nix/pull/331/files#diff-23f6eebd3059eac8e494796cdb5123595ff9c690e25518c08270ac48508acefbL105) and `BuildNixEvalStatusGenerator.end_formatter` were set to `IRenderable`, but `MessageFormatterBase` neither `MessageFormatterRenderable` is `IRenderable` (it doesn't implement the required signature either) so not sure what the type is supposed to be here