### PR TITLE
OAuth2ProxyAuth: initializing AuthBase.userInfoProvider

### DIFF
--- a/buildbot_nix/buildbot_nix/oauth2_proxy_auth.py
+++ b/buildbot_nix/buildbot_nix/oauth2_proxy_auth.py
@@ -17,13 +17,12 @@ log = Logger()
 class OAuth2ProxyAuth(AuthBase):
     header: ClassVar[bytes] = b"Authorization"
     prefix: ClassVar[bytes] = b"Basic "
-    user_info_provider: UserInfoProviderBase
     password: bytes
 
     def __init__(self, password: str, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        if self.user_info_provider is None:
-            self.user_info_provider = UserInfoProviderBase()
+        if self.userInfoProvider is None:
+            self.userInfoProvider = UserInfoProviderBase()
         self.password = unicode2bytes(password)
 
     def getLoginResource(self) -> IResource:  # noqa: N802


### PR DESCRIPTION
Setting up buildbot-nix with oauth2-proxy gives error:

```
buildbot_nix/oauth2_proxy_auth.py", line 25, in __init__
twistd[708]: if self.user_info_provider is None:
twistd[708]:     builtins.AttributeError: 'OAuth2ProxyAuth' object has no attribute 'user_info_provider'

```
There is also an issue that the user isn't granted 'admins' role if user_info_provider is used instead of userInfoProvider.