### PR TITLE
Fix repository configuration not being recognized

### DIFF
--- a/buildbot_nix/buildbot_nix/repo_config/__init__.py
+++ b/buildbot_nix/buildbot_nix/repo_config/__init__.py
@@ -33,7 +33,7 @@ class BranchConfig(BaseModel):
             command=[
                 "sh",
                 "-c",
-                "if [ -f buildbot-nix.toml ] then; then cat buildbot-nix.toml; fi",
+                "if [ -f buildbot-nix.toml ]; then cat buildbot-nix.toml; fi",
             ],
         )
         await buildstep.runCommand(cmd)


### PR DESCRIPTION
Seems like there was a bug there all along, without this the repository config system wouldn't ever trigger.