### PR TITLE
Set `default_branch` property

### DIFF
--- a/buildbot_nix/buildbot_nix/__init__.py
+++ b/buildbot_nix/buildbot_nix/__init__.py
@@ -237,6 +237,7 @@ class BuildTrigger(buildstep.ShellMixin, steps.BuildStep):
         props.setProperty("virtual_builder_tags", "", source)
         props.setProperty("attr", job.attr, source)
         props.setProperty("combine_builds", combine_builds, source)
+        props.setProperty("default_branch", project.default_branch, source)
 
         if isinstance(job, NixEvalJobSuccess):
             props.setProperty("drv_path", job.drvPath, source)


### PR DESCRIPTION
Without this property gcroots wouldn't get created and thanks to `getProperty` silently failing.