### PR TITLE
don't log environment for evaluation and building

### DIFF
--- a/buildbot_nix/buildbot_nix/__init__.py
+++ b/buildbot_nix/buildbot_nix/__init__.py
@@ -1076,6 +1076,7 @@ def nix_eval_config(
             worker_count=worker_count,
             max_memory_size=max_memory_size,
             drv_gcroots_dir=drv_gcroots_dir,
+            logEnviron=False,
         ),
     )
 
@@ -1171,6 +1172,7 @@ def nix_build_steps(
             # We increase this over the default since the build output might end up in a different `nix build`.
             timeout=60 * 60 * 3,
             haltOnFailure=True,
+            logEnviron=False,
         ),
         *post_build_steps,
         Trigger(


### PR DESCRIPTION

For nix we don't depend really on interesting environment variables.
This reduces some noice from the log.