### PR TITLE
buildbot_effects: bind nix daemon socket, set NIX_REMOTE

### DIFF
--- a/buildbot_effects/buildbot_effects/__init__.py
+++ b/buildbot_effects/buildbot_effects/__init__.py
@@ -190,6 +190,7 @@ def run_effects(
     env["HERCULES_CI_SECRETS_JSON"] = "/run/secrets.json"
     env["NIX_BUILD_TOP"] = "/build"
     env["TMPDIR"] = "/tmp"  # noqa: S108
+    env["NIX_REMOTE"] = "daemon"
     clear_env = set()
     clear_env.add("TMP")
     clear_env.add("TEMP")
@@ -235,6 +236,9 @@ def run_effects(
         "/nix/store",
         "--hostname",
         "hercules-ci",
+        "--bind",
+        "/nix/var/nix/daemon-socket/socket",
+        "/nix/var/nix/daemon-socket/socket",
     ]
 
     with NamedTemporaryFile() as tmp:


### PR DESCRIPTION
https://github.com/hercules-ci/hercules-ci-agent/blob/cae08186393d9736f2b3a5d30b2c7efe5569e337/hercules-ci-agent/src/Hercules/Effect.hs

The socket handling in hercules isn't simple, not sure if any more of it is necessary here.