### PR TITLE
fix: nixpkgs no aliases

### DIFF
--- a/nix/checks/flake-module.nix
+++ b/nix/checks/flake-module.nix
@@ -10,7 +10,7 @@
             inherit self pkgs;
           };
         in
-        lib.mkIf (pkgs.hostPlatform.isLinux) {
+        lib.mkIf (pkgs.stdenv.hostPlatform.isLinux) {
           master = import ./master.nix checkArgs;
           worker = import ./worker.nix checkArgs;
           effects = import ./effects.nix checkArgs;

--- a/nix/master.nix
+++ b/nix/master.nix
@@ -536,7 +536,7 @@ in
       };
       buildSystems = lib.mkOption {
         type = lib.types.listOf lib.types.str;
-        default = [ pkgs.hostPlatform.system ];
+        default = [ pkgs.stdenv.hostPlatform.system ];
         description = "Systems that we will be build";
       };
       evalMaxMemorySize = lib.mkOption {


### PR DESCRIPTION
Using https://nixos.org/manual/nixpkgs/stable/#opt-allowAliases means that all mentions of `pkgs.hostPlatform` will fail to evaluate since `pkgs.hostPlatform` is a alias see https://github.com/NixOS/nixpkgs/blob/6fa3bffe7919b63d9fbd32cee9bde440f3e180ab/pkgs/top-level/aliases.nix#L1668