### PR TITLE
buildbot-effects: Don't manually handle stdout/err

### DIFF
--- a/buildbot_effects/buildbot_effects/__init__.py
+++ b/buildbot_effects/buildbot_effects/__init__.py
@@ -260,18 +260,11 @@ def run_effects(
         with pipe() as (r_file, w_file):
             if debug:
                 print("$", shlex.join(bubblewrap_cmd), file=sys.stderr)
-            proc = subprocess.Popen(
+            proc = subprocess.run(
                 bubblewrap_cmd,
-                text=True,
+                check=False,
                 stdin=subprocess.DEVNULL,
-                stdout=w_file,
-                stderr=w_file,
             )
-            w_file.close()
-            with proc:
-                for line in r_file:
-                    print(line, end="")
-                proc.wait()
-                if proc.returncode != 0:
-                    msg = f"command failed with exit code {proc.returncode}"
-                    raise BuildbotEffectsError(msg)
+            if proc.returncode != 0:
+                msg = f"command failed with exit code {proc.returncode}"
+                raise BuildbotEffectsError(msg)


### PR DESCRIPTION
Instead of doing Popen with a piped stderr / stdin and then reading/printing what we read, let's instead just hand the existing stdout/err through to the spawned process. It saves complexity and ensures that no IO buffering messes up line-wise output.

In my tests, this fixes #406, resulting in an acceptable logline-streaming cadence (about 2 or three at a time instead of batches of 50).