### PR TITLE
buildbot_effects: bind /bin/sh

### DIFF
--- a/buildbot_effects/buildbot_effects/__init__.py
+++ b/buildbot_effects/buildbot_effects/__init__.py
@@ -240,6 +240,9 @@ def run_effects(
         "--bind",
         "/nix/var/nix/daemon-socket/socket",
         "/nix/var/nix/daemon-socket/socket",
+        "--ro-bind",
+        "/bin/sh",
+        "/bin/sh",
     ]
 
     with NamedTemporaryFile() as tmp:

--- a/buildbot_nix/buildbot_nix/worker.py
+++ b/buildbot_nix/buildbot_nix/worker.py
@@ -25,11 +25,12 @@ class WorkerConfig:
     worker_name: str = field(
         default_factory=lambda: os.environ.get("WORKER_NAME", socket.gethostname())
     )
-    worker_count_str: str | None = os.environ.get("WORKER_COUNT")
-    if worker_count_str is not None:
-        worker_count = int(worker_count_str)
-    else:
+    worker_count_str: str = os.environ.get("WORKER_COUNT", "0")
+    worker_count = int(worker_count_str)
+
+    if worker_count == 0:
         worker_count = multiprocessing.cpu_count()
+
     buildbot_dir: Path = field(
         default_factory=lambda: Path(require_env("BUILDBOT_DIR"))
     )


### PR DESCRIPTION
Error started with 2.24 -> 2.28 nix bump. https://github.com/nix-community/infra/pull/1768#issuecomment-2788784442

Looks like it is from https://github.com/NixOS/nix/commit/a03bb4455cee010bbfcf7e322b10ec7e35123032.
```
Couldn't execute /bin/sh -c "echo started": No such file or directory
```
