### PR TITLE
Add lib.interpolate function back

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
           ./examples/flake-module.nix
           ./devShells/flake-module.nix
           ./nixosModules/flake-module.nix
+          ./nix/flake-module.nix
           ./checks/flake-module.nix
           ./packages/flake-module.nix
         ]
@@ -38,6 +39,5 @@
         "aarch64-linux"
         "aarch64-darwin"
       ];
-
     };
 }

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -1,0 +1,5 @@
+{
+  flake = {
+    lib = import ./lib.nix;
+  };
+}

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,0 +1,24 @@
+{
+  /**
+    Marks a string as a value that will be interpolated on the buildbot master or worker.
+
+    See https://docs.buildbot.net/latest/manual/configuration/properties.html#interpolate
+    for details on the semantics of the interpolation format string.
+
+    Note that the `kw` selector (and passing keyword arguments) is not supported.
+
+    # Type
+    ```
+    interpolate :: String -> InterpolateString
+    ```
+
+    # Arguments
+
+    value
+    : The interpolation format string.
+  */
+  interpolate = value: {
+    _type = "interpolate";
+    inherit value;
+  };
+}


### PR DESCRIPTION
This seems to have gotten dropped in #429, but it's part of the exported interface by now (and I use & need it for accessing my attic cache).

This PR adds back the `lib` flake attribute, and the `interpolate` attribute; this time it includes documentation (in nix-community/nixdoc format).