### PR TITLE
add patch to fix deprecation warnings

### DIFF
--- a/packages/buildbot.nix
+++ b/packages/buildbot.nix
@@ -6,5 +6,10 @@ buildbot.overrideAttrs (o: {
       url = "https://github.com/buildbot/buildbot/commit/f08eeef96e15c686a4f6ad52368ad08246314751.patch";
       hash = "sha256-ACPYXMbjIfw02gsKwmDKIIZkGSxxLWCaW7ceEcgbtIU=";
     })
+    (fetchpatch {
+      name = "fix-deprecation-warnings.patch";
+      url = "https://github.com/buildbot/buildbot/commit/a894300c5085be925f5021bae2058492625a786b.patch";
+      hash = "sha256-agxubz/5PSw4WL3/d63GVnTKy67mLmL9pbVeImvbrYA=";
+    })
   ];
 })


### PR DESCRIPTION
On 4.2.* deprecation warnings cause exceptions instead of just being logged, this was fixed in 4.3.