### PR TITLE
Rebuild cached failures on proper workers

### DIFF
--- a/buildbot_nix/buildbot_nix/__init__.py
+++ b/buildbot_nix/buildbot_nix/__init__.py
@@ -349,14 +349,20 @@ class CachedFailureStep(steps.BuildStep):
                 error_log.addStderr("\n".join(msg) + "\n")
             return util.FAILURE
         self.build.addStepsAfterCurrentStep(
-            nix_build_steps(
-                self.project,
-                self.worker_names,
-                self.post_build_steps,
-                self.branch_config_dict,
-                self.outputs_path,
-                self.show_trace,
-            )
+            [
+                Trigger(
+                    name="Rebuild cached failure",
+                    waitForFinish=True,
+                    schedulerNames=[f"{self.project.project_id}-rebuild"],
+                    haltOnFailure=True,
+                    flunkOnFailure=True,
+                    sourceStamps=[],
+                    alwaysUseLatest=False,
+                    updateSourceStamp=False,
+                    copy_properties=["attr", "system", "branch", "revision"],
+                    set_properties={"reason": "rebuild"},
+                )
+            ]
         )
         return util.SUCCESS
 
@@ -1074,6 +1080,11 @@ def config_for_project(
             schedulers.Triggerable(
                 name=f"{project.project_id}-nix-register-gcroot",
                 builderNames=[f"{project.name}/nix-register-gcroot"],
+            ),
+            # this is triggered from cached failure rebuilds
+            schedulers.Triggerable(
+                name=f"{project.project_id}-rebuild",
+                builderNames=[f"{project.name}/nix-eval"],
             ),
             # allow to manually trigger a nix-build
             schedulers.ForceScheduler(


### PR DESCRIPTION
When a user triggers a rebuild for a cached failure, this runs on one of the `SKIPPED_BUILDER_NAMES` workers which I believe don't have a proper PATH and end up failing because the worker can't find the nix binary. You can see one such failed rebuild [in the NGI buildbot here](https://buildbot.ngi.nixos.org/#/builders/936/builds/483).

In order to keep the skipped builders setup as simple as possible, I've opted to add a trigger for a complete `nix-eval` in such cases (which should go to our regular builders). Running just `nix-build` could fail if drvs had been GC'ed (or I guess with multiple workers and not a singular cache).

I'm not sure if there's a better way to do this in buildbot, if there are better ideas let me know and I can try to implement them. The current implementation works in my testing.