### PR TITLE
repo_config: switch stdioLogName back to None

### DIFF
--- a/buildbot_nix/buildbot_nix/repo_config/__init__.py
+++ b/buildbot_nix/buildbot_nix/repo_config/__init__.py
@@ -28,7 +28,7 @@ class BranchConfig(BaseModel):
         cmd = await buildstep.makeRemoteShellCommand(
             collectStdout=True,
             collectStderr=True,
-            stdioLogName="stdio",
+            stdioLogName=None,
             # TODO: replace this with something like buildbot.steps.transfer.StringUpload
             # in the future... this one doesn't not exist yet.
             command=[


### PR DESCRIPTION
@Mic92 Was there a reason you changed this from `None` in https://github.com/nix-community/buildbot-nix/commit/323f88825bf3a430ac7d13f768c1fd772a215763, `None` still seems to work?

Using `toml` works but shows two log sections under `Evaluate flake`: https://buildbot.nix-community.org/#/builders/4466/builds/478