### PR TITLE
Make github/gitea ci statuses appear earlier for eval and add statuses for deployment

### DIFF
--- a/buildbot_nix/buildbot_nix/__init__.py
+++ b/buildbot_nix/buildbot_nix/__init__.py
@@ -100,6 +100,21 @@ class BuildbotEffectsTrigger(Trigger):
             **kwargs,
         )
 
+    async def run(self) -> int:  # type: ignore[override]
+        if self.build:
+            await CombinedBuildEvent.produce_event_for_build(
+                self.master, CombinedBuildEvent.STARTED_NIX_EFFECTS, self.build, None
+            )
+
+        results = await super().run()
+
+        if self.build:
+            await CombinedBuildEvent.produce_event_for_build(
+                self.master, CombinedBuildEvent.FINISHED_NIX_EFFECTS, self.build, None
+            )
+
+        return results
+
     def createTriggerProperties(self, props: Any) -> Any:  # noqa: N802
         return props
 

--- a/buildbot_nix/buildbot_nix/__init__.py
+++ b/buildbot_nix/buildbot_nix/__init__.py
@@ -181,7 +181,7 @@ class NixEvalCommand(buildstep.ShellMixin, steps.BuildStep):
         )
 
     async def run(self) -> int:
-        await self.produce_event("started-nix-eval", None)
+        await self.produce_event(CombinedBuildEvent.STARTED_NIX_EVAL.value, None)
 
         branch_config: BranchConfig = await BranchConfig.extract_during_step(self)
 

--- a/buildbot_nix/buildbot_nix/nix_status_generator.py
+++ b/buildbot_nix/buildbot_nix/nix_status_generator.py
@@ -29,6 +29,8 @@ class CombinedBuildEvent(Enum):
     FINISHED_NIX_EVAL = "finished-nix-eval"
     STARTED_NIX_BUILD = "started-nix-build"
     FINISHED_NIX_BUILD = "finished-nix-build"
+    STARTED_NIX_EFFECTS = "started-nix-effects"
+    FINISHED_NIX_EFFECTS = "finished-nix-effects"
 
     @staticmethod
     async def produce_event_for_build_requests_by_id(
@@ -88,6 +90,8 @@ class BuildNixEvalStatusGenerator(BuildStatusGeneratorMixin):
         ("builds", None, str(CombinedBuildEvent.FINISHED_NIX_EVAL.name)),
         ("builds", None, str(CombinedBuildEvent.STARTED_NIX_BUILD.name)),
         ("builds", None, str(CombinedBuildEvent.FINISHED_NIX_BUILD.name)),
+        ("builds", None, str(CombinedBuildEvent.STARTED_NIX_EFFECTS.name)),
+        ("builds", None, str(CombinedBuildEvent.FINISHED_NIX_EFFECTS.name)),
         ("buildrequests", None, str(CombinedBuildEvent.STARTED_NIX_BUILD.name)),
         ("buildrequests", None, str(CombinedBuildEvent.FINISHED_NIX_BUILD.name)),
     ]
@@ -223,6 +227,14 @@ class BuildNixEvalStatusGenerator(BuildStatusGeneratorMixin):
                             "nix-build",
                             "generator",
                         )
+                case (
+                    CombinedBuildEvent.STARTED_NIX_EFFECTS
+                    | CombinedBuildEvent.FINISHED_NIX_EFFECTS
+                ):
+                    report["builds"][0]["properties"]["status_name"] = (
+                        "nix-effects",
+                        "generator",
+                    )
                 case _:
                     msg = f"Unexpected event: {event_typed}"
                     raise ValueError(msg)
@@ -231,6 +243,7 @@ class BuildNixEvalStatusGenerator(BuildStatusGeneratorMixin):
                 case (
                     CombinedBuildEvent.FINISHED_NIX_EVAL
                     | CombinedBuildEvent.FINISHED_NIX_BUILD
+                    | CombinedBuildEvent.FINISHED_NIX_EFFECTS
                 ):
                     report["builds"][0]["complete"] = True
                     report["builds"][0]["complete_at"] = datetime.now(tz=UTC)

--- a/buildbot_nix/buildbot_nix/nix_status_generator.py
+++ b/buildbot_nix/buildbot_nix/nix_status_generator.py
@@ -72,28 +72,26 @@ class CombinedBuildEvent(Enum):
             build_db: Any = await master.data.get(("builds", str(build.buildid)))
             if result is not None:
                 build_db["results"] = result
-            master.mq.produce(
-                ("builds", str(build.buildid), event.name), copy.deepcopy(build_db)
-            )
+            event_key = ("builds", str(build.buildid), event.value)
+            master.mq.produce(event_key, copy.deepcopy(build_db))
         elif isinstance(build, dict):
             if result is not None:
                 build["results"] = result
-            master.mq.produce(
-                ("builds", str(build["buildid"]), event.name), copy.deepcopy(build)
-            )
+            event_key = ("builds", str(build["buildid"]), event.value)
+            master.mq.produce(event_key, copy.deepcopy(build))
 
 
 @implementer(IReportGenerator)
 class BuildNixEvalStatusGenerator(BuildStatusGeneratorMixin):
     wanted_event_keys: ClassVar[list[Any]] = [
-        ("builds", None, str(CombinedBuildEvent.STARTED_NIX_EVAL.name)),
-        ("builds", None, str(CombinedBuildEvent.FINISHED_NIX_EVAL.name)),
-        ("builds", None, str(CombinedBuildEvent.STARTED_NIX_BUILD.name)),
-        ("builds", None, str(CombinedBuildEvent.FINISHED_NIX_BUILD.name)),
-        ("builds", None, str(CombinedBuildEvent.STARTED_NIX_EFFECTS.name)),
-        ("builds", None, str(CombinedBuildEvent.FINISHED_NIX_EFFECTS.name)),
-        ("buildrequests", None, str(CombinedBuildEvent.STARTED_NIX_BUILD.name)),
-        ("buildrequests", None, str(CombinedBuildEvent.FINISHED_NIX_BUILD.name)),
+        ("builds", None, CombinedBuildEvent.STARTED_NIX_EVAL.value),
+        ("builds", None, CombinedBuildEvent.FINISHED_NIX_EVAL.value),
+        ("builds", None, CombinedBuildEvent.STARTED_NIX_BUILD.value),
+        ("builds", None, CombinedBuildEvent.FINISHED_NIX_BUILD.value),
+        ("builds", None, CombinedBuildEvent.STARTED_NIX_EFFECTS.value),
+        ("builds", None, CombinedBuildEvent.FINISHED_NIX_EFFECTS.value),
+        ("buildrequests", None, CombinedBuildEvent.STARTED_NIX_BUILD.value),
+        ("buildrequests", None, CombinedBuildEvent.FINISHED_NIX_BUILD.value),
     ]
 
     compare_attrs: ClassVar[list[str]] = ["start_formatter", "end_formatter"]
@@ -185,9 +183,14 @@ class BuildNixEvalStatusGenerator(BuildStatusGeneratorMixin):
     ) -> None | dict[str, Any]:
         what, _, event = key
         if what == "builds":
-            is_new = event == "new"
+            # Check if this is a start event
+            is_start_event = event in [
+                CombinedBuildEvent.STARTED_NIX_EVAL.value,
+                CombinedBuildEvent.STARTED_NIX_BUILD.value,
+                CombinedBuildEvent.STARTED_NIX_EFFECTS.value,
+            ]
 
-            formatter = self.start_formatter if is_new else self.end_formatter
+            formatter = self.start_formatter if is_start_event else self.end_formatter
 
             await getDetailsForBuild(
                 master,
@@ -204,9 +207,8 @@ class BuildNixEvalStatusGenerator(BuildStatusGeneratorMixin):
             report: dict[str, Any] = await self.build_message(
                 formatter, master, reporter, data
             )
-
-            event_typed: CombinedBuildEvent = CombinedBuildEvent.__members__[event]
-            match event_typed:
+            event_type = CombinedBuildEvent(event)
+            match event_type:
                 case (
                     CombinedBuildEvent.STARTED_NIX_EVAL
                     | CombinedBuildEvent.FINISHED_NIX_EVAL
@@ -236,10 +238,10 @@ class BuildNixEvalStatusGenerator(BuildStatusGeneratorMixin):
                         "generator",
                     )
                 case _:
-                    msg = f"Unexpected event: {event_typed}"
+                    msg = f"Unexpected event: {event_type}"
                     raise ValueError(msg)
 
-            match event_typed:
+            match event_type:
                 case (
                     CombinedBuildEvent.FINISHED_NIX_EVAL
                     | CombinedBuildEvent.FINISHED_NIX_BUILD


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added start and finish notifications for the nix-effects phase.
  - Build status now includes a distinct nix-effects phase for better progress visibility.

- Bug Fixes
  - Improved completion detection: builds now correctly finish when nix-effects completes.
  - Clearer, more accurate status reporting and error messages during event processing.

- Refactor
  - Standardized event key usage for consistency across emitted and consumed events.
  - Aligned start/end handling to explicitly recognize start events, improving status update reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->