### PR TITLE
disable cached failed builds by default

### DIFF
--- a/buildbot_nix/buildbot_nix/build_trigger.py
+++ b/buildbot_nix/buildbot_nix/build_trigger.py
@@ -372,7 +372,7 @@ class BuildTrigger(buildstep.ShellMixin, steps.BuildStep):
                 scheduled.append(
                     BuildTrigger.ScheduledJob(failed_job, brids, results_deferred)
                 )
-                self.brids.extend(brids)
+                self.brids.extend(brids.values())
 
         return overall_result
 

--- a/buildbot_nix/buildbot_nix/models.py
+++ b/buildbot_nix/buildbot_nix/models.py
@@ -300,6 +300,7 @@ class BuildbotNixConfig(BaseModel):
     nix_workers_secret_file: Path | None = None
     effects_per_repo_secrets: dict[str, str] = {}
     show_trace_on_failure: bool = False
+    cache_failed_builds: bool = False
 
     def nix_worker_secrets(self) -> WorkerConfig:
         if self.nix_workers_secret_file is None:

--- a/nixosModules/master.nix
+++ b/nixosModules/master.nix
@@ -749,15 +749,17 @@ in
                     null
                   else
                     {
-                      user_allowlist = cfg.gitea.userAllowlist;
-                      repo_allowlist = cfg.gitea.repoAllowlist;
+                      filters = {
+                        user_allowlist = cfg.gitea.userAllowlist;
+                        repo_allowlist = cfg.gitea.repoAllowlist;
+                        topic = cfg.gitea.topic;
+                      };
                       token_file = "gitea-token";
                       webhook_secret_file = "gitea-webhook-secret";
                       project_cache_file = "gitea-project-cache.json";
                       oauth_secret_file = "gitea-oauth-secret";
                       instance_url = cfg.gitea.instanceUrl;
                       oauth_id = cfg.gitea.oauthId;
-                      topic = cfg.gitea.topic;
                       ssh_private_key_file = cfg.gitea.sshPrivateKeyFile;
                       ssh_known_hosts_file = cfg.gitea.sshKnownHostsFile;
                     };
@@ -766,8 +768,11 @@ in
                     null
                   else
                     {
-                      user_allowlist = cfg.github.userAllowlist;
-                      repo_allowlist = cfg.github.repoAllowlist;
+                      filters = {
+                        user_allowlist = cfg.github.userAllowlist;
+                        repo_allowlist = cfg.github.repoAllowlist;
+                        topic = cfg.github.topic;
+                      };
                       auth_type =
                         if (cfg.github.authType ? "legacy") then
                           { token_file = "github-token"; }
@@ -785,7 +790,6 @@ in
                       webhook_secret_file = "github-webhook-secret";
                       oauth_secret_file = "github-oauth-secret";
                       oauth_id = cfg.github.oauthId;
-                      topic = cfg.github.topic;
                     };
                 pull_based =
                   if cfg.pullBased.repositories == [ ] then

--- a/nixosModules/master.nix
+++ b/nixosModules/master.nix
@@ -569,6 +569,13 @@ in
         description = "Show stack traces on failed evaluations";
       };
 
+      cacheFailedBuilds = lib.mkEnableOption ''
+        cache failed builds in local database to avoid retrying them.
+        When enabled, failed builds will be remembered and skipped in subsequent evaluations
+        unless explicitly rebuilt. When disabled (the default), all builds will be attempted
+        regardless of previous failures
+      '';
+
       outputsPath = lib.mkOption {
         type = lib.types.nullOr lib.types.path;
         description = "Path where we store the latest build store paths names for nix attributes as text files. This path will be exposed via nginx at \${domain}/nix-outputs";
@@ -815,6 +822,7 @@ in
                 branches = cfg.branches;
                 nix_workers_secret_file = "buildbot-nix-workers";
                 show_trace_on_failure = cfg.showTrace;
+                cache_failed_builds = cfg.cacheFailedBuilds;
               }
             }").read_text()))
           )


### PR DESCRIPTION
This option was added for package sets where some packages may fail consistently. However most projects we have an always green CI most of the time. In those projects this caching can be annoying because it also effects builds with temporary failures (i.e. broken remote builders, network failures). For contributors without permissions to restart builds, this error can be annoying and confusing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add enableable option to cache failed builds; when enabled, failures may be recorded and skipped on subsequent evaluations (disabled by default).
  * Service can operate without a failed-builds database when caching is disabled; caching paths are skipped in that case.
  * Generated master configuration now exposes the cache flag and groups provider allowlists and topic under a unified "filters" object.

* **Refactor**
  * Internal scheduling and state plumbing reorganized for clearer context handling (no behavioral change when DB present).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->