### PR TITLE
 Report failed builds directly in github 

### DIFF
--- a/buildbot_nix/buildbot_nix/__init__.py
+++ b/buildbot_nix/buildbot_nix/__init__.py
@@ -70,7 +70,7 @@ class NixEvalConfig:
     """Configuration for nix evaluation."""
 
     supported_systems: list[str]
-    job_report_limit: int | None
+    failed_build_report_limit: int
     worker_count: int
     max_memory_size: int
 
@@ -295,14 +295,12 @@ class NixEvalCommand(buildstep.ShellMixin, steps.BuildStep):
                     dependency_failed_scheduler=f"{self.project.project_id}-nix-dependency-failed",
                     cached_failure_scheduler=f"{self.project.project_id}-nix-cached-failure",
                 )
+
                 jobs_config = JobsConfig(
                     successful_jobs=successful_jobs,
                     failed_jobs=failed_jobs,
-                    combine_builds=(
-                        self.nix_eval_config.job_report_limit is not None
-                        and self.number_of_jobs > self.nix_eval_config.job_report_limit
-                    ),
                     failed_builds_db=self.nix_eval_config.failed_builds_db,
+                    failed_build_report_limit=self.nix_eval_config.failed_build_report_limit,
                 )
                 self.build.addStepsAfterCurrentStep(
                     [
@@ -310,6 +308,7 @@ class NixEvalCommand(buildstep.ShellMixin, steps.BuildStep):
                             project=self.project,
                             trigger_config=trigger_config,
                             jobs_config=jobs_config,
+                            nix_attr_prefix=branch_config.attribute,
                             name="build flake",
                         ),
                     ]
@@ -559,31 +558,11 @@ class NixBuildCommand(buildstep.ShellMixin, steps.BuildStep):
         super().__init__(**kwargs)
 
     async def run(self) -> int:
-        if (
-            self.build
-            and self.build.reason == "rebuild"
-            and not self.getProperty("combine_builds")
-        ):
-            await CombinedBuildEvent.produce_event_for_build(
-                self.master, CombinedBuildEvent.STARTED_NIX_BUILD, self.build, None
-            )
-
         # run `nix build`
         cmd: remotecommand.RemoteCommand = await self.makeRemoteShellCommand()
         await self.runCommand(cmd)
 
-        res = cmd.results()
-
-        if (
-            self.build
-            and self.build.reason == "rebuild"
-            and not self.getProperty("combine_builds")
-        ):
-            await CombinedBuildEvent.produce_event_for_build(
-                self.master, CombinedBuildEvent.FINISHED_NIX_BUILD, self.build, res
-            )
-
-        return res
+        return cmd.results()
 
 
 class RegisterSkippedGcroots(buildstep.ShellMixin, steps.BuildStep):
@@ -719,7 +698,7 @@ class UpdateBuildOutput(steps.BuildStep):
         return util.SUCCESS
 
 
-# GitHub somtimes fires the PR webhook before it has computed the merge commit
+# GitHub sometimes fires the PR webhook before it has computed the merge commit
 # This is a workaround to fetch the merge commit and checkout the PR branch in CI
 class GitLocalPrMerge(steps.Git):
     async def run_vc(
@@ -1523,7 +1502,7 @@ class NixConfigurator(ConfiguratorBase):
                         worker_names=worker_names,
                         nix_eval_config=NixEvalConfig(
                             supported_systems=self.config.build_systems,
-                            job_report_limit=self.config.job_report_limit,
+                            failed_build_report_limit=self.config.failed_build_report_limit,
                             worker_count=self.config.eval_worker_count
                             or multiprocessing.cpu_count(),
                             max_memory_size=self.config.eval_max_memory_size,

--- a/buildbot_nix/buildbot_nix/__init__.py
+++ b/buildbot_nix/buildbot_nix/__init__.py
@@ -354,7 +354,7 @@ class NixEvalCommand(buildstep.ShellMixin, steps.BuildStep):
                 <span style="margin-right: 10px;">⚠️</span>
                 <span>Found {self.warnings_count} Evaluation Warning{"s" if self.warnings_count != 1 else ""}</span>
             </h3>
-            <div style="space-y: 10px;">
+            <div>
                 {"".join(warnings_html)}
             </div>
             </div>""",

--- a/buildbot_nix/buildbot_nix/build_trigger.py
+++ b/buildbot_nix/buildbot_nix/build_trigger.py
@@ -517,7 +517,7 @@ class BuildTrigger(buildstep.ShellMixin, steps.BuildStep):
                 skipped_jobs.append(job)
                 self._skipped_count += 1
 
-        # Update summary once after processing all skipped jobs in this batch
+        # Update summary after processing skipped jobs
         if skipped_jobs:
             self.updateSummary()
 
@@ -676,21 +676,22 @@ class BuildTrigger(buildstep.ShellMixin, steps.BuildStep):
 
     def getCurrentSummary(self) -> dict[str, str]:  # noqa: N802
         summary = []
+
+        # Show completed build results
         if self._result_list:
             for status in ALL_RESULTS:
                 count = self._result_list.count(status)
                 if count:
                     summary.append(
-                        f"{self._result_list.count(status)} {statusToString(status, count)}",
+                        f"{count} {statusToString(status, count)}",
                     )
 
-        # Add skipped count if any
+        # Show skipped builds
         if self._skipped_count > 0:
             summary.append(f"{self._skipped_count} skipped")
 
-        # Add total count if we have any builds (built or skipped)
-        total = len(self._result_list) + self._skipped_count
-        if total > 0:
-            summary.append(f"{total} total")
-
         return {"step": f"({', '.join(summary)})"}
+
+    def getResultSummary(self) -> dict[str, str]:  # noqa: N802
+        """Get the final summary when the step completes."""
+        return self.getCurrentSummary()

--- a/buildbot_nix/buildbot_nix/models.py
+++ b/buildbot_nix/buildbot_nix/models.py
@@ -292,7 +292,9 @@ class BuildbotNixConfig(BaseModel):
     pull_based: PullBasedConfig | None
     outputs_path: Path | None = None
     post_build_steps: list[PostBuildStep] = []
-    job_report_limit: int | None = None
+    failed_build_report_limit: int = (
+        47  # Default: 50 total - 3 reserved for eval/build/effects
+    )
     http_basic_auth_password_file: Path | None = None
     branches: BranchConfigDict = BranchConfigDict({})
     gcroots_user: str = "buildbot-worker"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable Nix attribute prefix for triggered builds.
  * Per-run limit on individual failed-build notifications (defaults to 47) with throttling and caching.
  * Evaluation warnings are processed asynchronously, formatted as HTML, and can promote final results to "warnings".

* **Refactor**
  * Public option renamed for clarity (backwards-compatible alias preserved) and default adjusted to reserve slots for eval/build/effects.
  * Simplified build signaling and improved per-status result summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->