### PR TITLE
Fix updating output paths in skipped builds 

### DIFF
--- a/buildbot_nix/buildbot_nix/__init__.py
+++ b/buildbot_nix/buildbot_nix/__init__.py
@@ -690,7 +690,7 @@ class ProcessSkippedBuilds(buildstep.ShellMixin, steps.BuildStep):
             and self.branch_config.do_update_outputs(
                 self.project.default_branch, props.getProperty("branch")
             )
-            and props.getProperty("event") == "push"
+            and props.getProperty("event", "push") == "push"
         ):
             branch = props.getProperty("branch")
             for attr, out_path in skipped_outputs.items():
@@ -887,7 +887,7 @@ def nix_eval_config(
             branch_config=build_config.branch_config_dict,
             outputs_path=build_config.outputs_path,
             name="Process skipped builds",
-            doStepIf=lambda s: s.getProperty("event") == "push"
+            doStepIf=lambda s: (s.getProperty("event", "push") == "push")
             and build_config.branch_config_dict.do_register_gcroot(
                 project.default_branch, s.getProperty("branch")
             ),
@@ -949,7 +949,7 @@ async def do_register_gcroot_if(
     out_path = s.getProperty("out_path")
 
     return (
-        s.getProperty("event") == "push"
+        s.getProperty("event", "push") == "push"
         and branch_config.do_register_gcroot(
             s.getProperty("default_branch"), s.getProperty("branch")
         )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Skipped builds are now processed to register gcroots and optionally write per-branch output path files.
  - Added configurable outputs directory for persisting build outputs.
  - Improved cross-system support by using dynamic system detection in checks and builds.

- Bug Fixes
  - Safer output handling with traversal-safe path joins to prevent writing outside the outputs directory.
  - More robust event handling during gcroot registration.

- Tests
  - Added test verifying output paths are written for skipped builds and match evaluated values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->