### PR TITLE
add niks3 binary cache support

### DIFF
--- a/nixosModules/master.nix
+++ b/nixosModules/master.nix
@@ -42,6 +42,7 @@ in
   imports = [
     ./packages.nix
     ./cachix.nix
+    ./niks3.nix
     (mkRenamedOptionModule
       [
         "services"

--- a/nixosModules/niks3.nix
+++ b/nixosModules/niks3.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.buildbot-nix.master;
+  interpolate = value: {
+    _type = "interpolate";
+    inherit value;
+  };
+in
+{
+  options.services.buildbot-nix.master.niks3 = {
+    enable = lib.mkEnableOption "Enable niks3 integration";
+
+    serverUrl = lib.mkOption {
+      type = lib.types.str;
+      description = "niks3 server URL";
+      example = "https://niks3.yourdomain.com";
+    };
+
+    authTokenFile = lib.mkOption {
+      type = lib.types.path;
+      description = ''
+        Path to a file containing the niks3 API authentication token.
+      '';
+    };
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default =
+        pkgs.niks3 or (throw "niks3 package not found in pkgs. Please add niks3 flake input and overlay.");
+      description = "The niks3 package to use";
+    };
+  };
+
+  config = lib.mkIf cfg.niks3.enable {
+    systemd.services.buildbot-master.serviceConfig.LoadCredential = [
+      "niks3-auth-token:${builtins.toString cfg.niks3.authTokenFile}"
+    ];
+
+    systemd.services.buildbot-worker.path = [ cfg.niks3.package ];
+
+    services.buildbot-nix.master.postBuildSteps = [
+      {
+        name = "Upload to niks3";
+        environment = {
+          NIKS3_SERVER_URL = cfg.niks3.serverUrl;
+        };
+        command = [
+          "niks3" # note that this is the niks3 from the worker's $PATH
+          "push"
+          "--auth-token"
+          (interpolate "%(secret:niks3-auth-token)s")
+          (interpolate "result-%(prop:attr)s")
+        ];
+      }
+    ];
+  };
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Niks3 integration for build results.
  * New configuration options: enable toggle, server URL, authentication token file path, and package selection for the uploader.
  * When enabled, build results are uploaded to Niks3 via a post-build step.
  * Authentication token is loaded securely via system credential mechanism and the uploader is made available to build workers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->