### PR TITLE
post build steps now can be marked as non-critical

### DIFF
--- a/buildbot_nix/buildbot_nix/models.py
+++ b/buildbot_nix/buildbot_nix/models.py
@@ -165,6 +165,7 @@ class PostBuildStep(BaseModel):
     name: str
     environment: Mapping[str, str | Interpolate]
     command: list[str | Interpolate]
+    warn_only: bool = False
 
     def to_buildstep(self) -> steps.BuildStep:
         return steps.ShellCommand(
@@ -174,6 +175,8 @@ class PostBuildStep(BaseModel):
                 for k in self.environment
             },
             command=[Interpolate.to_buildbot(x) for x in self.command],
+            warnOnFailure=self.warn_only,
+            flunkOnFailure=not self.warn_only,
         )
 
 

--- a/nixosModules/cachix.nix
+++ b/nixosModules/cachix.nix
@@ -131,6 +131,7 @@ in
           cfg.cachix.name
           (interpolate "result-%(prop:attr)s")
         ];
+        warnOnly = true; # Don't fail the build if cachix upload fails
       }
     ];
   };

--- a/nixosModules/niks3.nix
+++ b/nixosModules/niks3.nix
@@ -56,6 +56,7 @@ in
           (interpolate "%(secret:niks3-auth-token)s")
           (interpolate "result-%(prop:attr)s")
         ];
+        warnOnly = true; # Don't fail the build if niks3 upload fails
       }
     ];
   };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a per-step warnOnly option for post-build steps to treat failures as warnings instead of failing the build (default: false).
  * Cachix and NixS3 upload steps now use warnOnly by default, so cache upload issues no longer fail builds.

* **Documentation**
  * Updated module option descriptions and examples to include the new warnOnly flag and illustrate its usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->