### PR TITLE
fix: handle None branch in build_canceller

### DIFF
--- a/buildbot_nix/buildbot_nix/build_canceller.py
+++ b/buildbot_nix/buildbot_nix/build_canceller.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 def branch_key_for_pr(build: dict[str, Any]) -> str:
     """Extract a unique key for PR/change to cancel old builds."""
-    branch = build.get("branch", "")
+    branch = build.get("branch") or ""
 
     # For GitHub/Gitea/GitLab PRs
     if branch.startswith(("refs/pull/", "refs/merge-requests/")):


### PR DESCRIPTION
Fixes #522 where buildbot-master fails to start with AttributeError when sourcestamp has an explicit None branch value. dict.get() only uses the default when the key is missing, not when the value is None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of builds with missing branch information to prevent potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->