### PR TITLE
feat: add allowAnonymousControl option for unrestricted access

### DIFF
--- a/buildbot_nix/buildbot_nix/__init__.py
+++ b/buildbot_nix/buildbot_nix/__init__.py
@@ -210,6 +210,7 @@ class NixConfigurator(ConfiguratorBase):
                 admins=self.config.admins,
                 backends=list(backends.values()),
                 projects=succeeded_projects,
+                allow_unauthenticated_control=self.config.allow_unauthenticated_control,
             )
 
     def configure(self, config: dict[str, Any]) -> None:

--- a/buildbot_nix/buildbot_nix/authz.py
+++ b/buildbot_nix/buildbot_nix/authz.py
@@ -100,9 +100,22 @@ class AnyProjectEndpointMatcher(EndpointMatcherBase):
 
 
 def setup_authz(
-    backends: list[GitBackend], projects: list[GitProject], admins: list[str]
+    backends: list[GitBackend],
+    projects: list[GitProject],
+    admins: list[str],
+    *,
+    allow_unauthenticated_control: bool = False,
 ) -> Authz:
     allow_rules = []
+
+    # When enabled, permit all control actions without authentication
+    if allow_unauthenticated_control:
+        allow_rules.append(util.AnyEndpointMatcher(role="", defaultDeny=False))
+        return util.Authz(
+            roleMatchers=[],
+            allowRules=allow_rules,
+        )
+
     allowed_builders_by_org: defaultdict[str, set[str]] = defaultdict(
         lambda: {backend.reload_builder_name for backend in backends},
     )

--- a/buildbot_nix/buildbot_nix/models.py
+++ b/buildbot_nix/buildbot_nix/models.py
@@ -298,6 +298,7 @@ class BuildbotNixConfig(BaseModel):
     effects_per_repo_secrets: dict[str, str] = {}
     show_trace_on_failure: bool = False
     cache_failed_builds: bool = False
+    allow_unauthenticated_control: bool = False
 
     def nix_worker_secrets(self) -> WorkerConfig:
         if self.nix_workers_secret_file is None:

--- a/examples/master.nix
+++ b/examples/master.nix
@@ -67,6 +67,10 @@
     # branches = {
     #   releaseBranches.matchGlob = "release-*";
     # };
+
+    # Allow unauthenticated users to perform control actions (cancel, restart, force builds).
+    # Useful when running buildbot behind a VPN or on a local network.
+    # allowUnauthenticatedControl = true;
   };
 
   # Optional: Enable acme/TLS in nginx (recommended)

--- a/nixosModules/master.nix
+++ b/nixosModules/master.nix
@@ -595,6 +595,12 @@ in
         regardless of previous failures
       '';
 
+      allowUnauthenticatedControl = lib.mkEnableOption ''
+        allowing unauthenticated users to perform control actions (cancel, restart,
+        force builds). Useful when running buildbot behind a VPN or on a local network
+        where network-level access implies trust
+      '';
+
       outputsPath = lib.mkOption {
         type = lib.types.nullOr lib.types.path;
         description = "Path where we store the latest build store paths names for nix attributes as text files. This path will be exposed via nginx at \${domain}/nix-outputs";
@@ -847,6 +853,7 @@ in
                 nix_workers_secret_file = "buildbot-nix-workers";
                 show_trace_on_failure = cfg.showTrace;
                 cache_failed_builds = cfg.cacheFailedBuilds;
+                allow_unauthenticated_control = cfg.allowUnauthenticatedControl;
               }
             }").read_text()))
           )


### PR DESCRIPTION
When running buildbot in a trusted environment (e.g., behind a VPN or
on a local network), it's useful to allow anyone who can access the
web UI to perform control actions without authentication.

This adds a new `allowAnonymousControl` option that, when combined with
`authBackend = "none"`, permits anonymous users to cancel builds,
restart builds, force builds, and perform other control actions.
