### PR TITLE
fix: improve documentation generation and first-install experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,20 +163,44 @@ Add the GitHub configuration to your NixOS module:
 
 ```nix
 services.buildbot-nix.master = {
+  enable = true;
+  domain = "buildbot.example.com";  # Your buildbot domain
+  workersFile = "/path/to/workers.json";  # See workers file format below
   authBackend = "github";
   github = {
     appId = <your-app-id>;  # The numeric App ID
     appSecretKeyFile = "/path/to/private-key.pem";  # Path to the downloaded private key
 
-    # Optional: Enable OAuth for user login
+    # Required for GitHub authBackend: Enable OAuth for user login
     oauthId = "<oauth-client-id>";
     oauthSecretFile = "/path/to/oauth-secret";
+
+    # A random secret used to verify incoming webhooks from GitHub
+    webhookSecretFile = "/path/to/webhook-secret";
 
     # Optional: Filter which repositories to build
     topic = "buildbot-nix";  # Only build repos with this topic
   };
 };
 ```
+
+**Workers File Format**:
+
+The `workersFile` option expects a JSON file containing an array of worker
+definitions:
+
+```json
+[
+  { "name": "worker1", "pass": "secret-password", "cores": 16 }
+]
+```
+
+- `name`: The worker name (matches `services.buildbot-nix.worker.name`, defaults
+  to hostname)
+- `pass`: The password (must match
+  `services.buildbot-nix.worker.workerPasswordFile` contents)
+- `cores`: Number of CPU cores (must match the actual core count of the worker
+  machine)
 
 ###### Step 3: Install the GitHub App
 

--- a/checks/lib.nix
+++ b/checks/lib.nix
@@ -10,8 +10,8 @@ let
 in
 (nixos-lib.runTest {
   hostPkgs = pkgs;
-  # This speeds up the evaluation by skipping evaluating documentation (optional)
-  defaults.documentation.enable = lib.mkDefault false;
+  # Enable documentation generation to catch missing descriptions
+  defaults.documentation.nixos.options.warningsAreErrors = true;
   # This makes `self` available in the NixOS configuration of our virtual machines.
   # This is useful for referencing modules or packages from your own flake
   # as well as importing from other flakes.

--- a/nixosModules/cachix.nix
+++ b/nixosModules/cachix.nix
@@ -20,6 +20,7 @@ in
     };
 
     auth = lib.mkOption {
+      description = "Authentication method for Cachix. Choose either signingKey or authToken.";
       type = lib.types.attrTag {
         signingKey = lib.mkOption {
           description = ''

--- a/nixosModules/master.nix
+++ b/nixosModules/master.nix
@@ -236,6 +236,7 @@ in
       };
 
       accessMode = lib.mkOption {
+        description = "Controls the access mode for the Buildbot instance. Choose between public (default) or fullyPrivate mode.";
         default = {
           public = { };
         };
@@ -573,6 +574,7 @@ in
         description = "URL base for the webhook endpoint that will be registered for github or gitea repos.";
         example = "https://buildbot-webhooks.numtide.com/";
         default = config.services.buildbot-master.buildbotUrl;
+        defaultText = lib.literalExpression "config.services.buildbot-master.buildbotUrl";
       };
       useHTTPS = lib.mkOption {
         type = lib.types.nullOr lib.types.bool;

--- a/nixosModules/niks3.nix
+++ b/nixosModules/niks3.nix
@@ -30,9 +30,7 @@ in
 
     package = lib.mkOption {
       type = lib.types.package;
-      default =
-        pkgs.niks3 or (throw "niks3 package not found in pkgs. Please add niks3 flake input and overlay.");
-      description = "The niks3 package to use";
+      description = "The niks3 package to use. You must add the niks3 flake input and overlay to make this package available.";
     };
   };
 

--- a/nixosModules/packages.nix
+++ b/nixosModules/packages.nix
@@ -12,42 +12,56 @@ in
     python = lib.mkOption {
       type = lib.types.package;
       default = config.services.buildbot-nix.packages.buildbot.python;
-      defaultText = "pkgs.python3";
-      description = "python interpreter to use for buildbot-nix";
+      defaultText = lib.literalExpression "config.services.buildbot-nix.packages.buildbot.python";
+      description = "Python interpreter to use for buildbot-nix.";
     };
 
     buildbot = lib.mkOption {
       type = lib.types.package;
       default = pkgs.callPackage ../packages/buildbot.nix { };
+      defaultText = lib.literalExpression "pkgs.callPackage ../packages/buildbot.nix { }";
+      description = "The buildbot package to use.";
     };
 
     buildbot-worker = lib.mkOption {
       type = lib.types.package;
       default = pkgs.buildbot-worker;
+      defaultText = lib.literalExpression "pkgs.buildbot-worker";
+      description = "The buildbot-worker package to use.";
     };
 
     buildbot-nix = lib.mkOption {
+      type = lib.types.package;
       default = cfg.python.pkgs.callPackage ../packages/buildbot-nix.nix {
         buildbot-gitea = cfg.buildbot-gitea;
       };
+      defaultText = lib.literalExpression "python.pkgs.callPackage ../packages/buildbot-nix.nix { }";
+      description = "The buildbot-nix package to use.";
     };
 
     buildbot-plugins = lib.mkOption {
       type = lib.types.attrsOf lib.types.package;
       default = pkgs.buildbot-plugins;
+      defaultText = lib.literalExpression "pkgs.buildbot-plugins";
+      description = "Attrset of buildbot plugin packages to use.";
     };
 
     buildbot-effects = lib.mkOption {
       type = lib.types.package;
       default = cfg.python.pkgs.callPackage ../packages/buildbot-effects.nix { };
+      defaultText = lib.literalExpression "python.pkgs.callPackage ../packages/buildbot-effects.nix { }";
+      description = "The buildbot-effects package to use.";
     };
 
     buildbot-gitea = lib.mkOption {
+      type = lib.types.package;
       default = (
         cfg.python.pkgs.callPackage ../packages/buildbot-gitea.nix {
           buildbot = cfg.buildbot;
         }
       );
+      defaultText = lib.literalExpression "python.pkgs.callPackage ../packages/buildbot-gitea.nix { }";
+      description = "The buildbot-gitea package to use.";
     };
   };
 }

--- a/nixosModules/worker.nix
+++ b/nixosModules/worker.nix
@@ -49,6 +49,7 @@ in
       name = lib.mkOption {
         type = lib.types.str;
         default = config.networking.hostName;
+        defaultText = lib.literalExpression "config.networking.hostName";
         description = "The buildbot worker name.";
       };
       nixEvalJobs.package = lib.mkOption {


### PR DESCRIPTION
Address feedback from issue #529 regarding first-install experience and documentation generation errors when using includeAllModules = true.

The README GitHub example was missing required options like domain, workersFile, and webhookSecretFile. Users had to examine test files to understand the workers.json format. This adds the missing options and documents the JSON format inline.

Several options referenced config values in their defaults without providing defaultText, causing documentation generation to fail when modules were included but not fully configured. Add defaultText to webhookBaseUrl, worker.name, and all package options.

Options like accessMode, cachix.auth, and the packages.* options lacked descriptions entirely, triggering warnings during documentation builds.

The niks3.package option had a throwing default that caused evaluation errors even when niks3 was disabled. Remove the default entirely so users must explicitly set the package when enabling niks3.

Enable warningsAreErrors in the test framework to catch similar issues in the future.

Fixes: #529