### PR TITLE
require & want `network-online.target` when using oauth

### DIFF
--- a/nixosModules/master.nix
+++ b/nixosModules/master.nix
@@ -988,7 +988,8 @@ in
     };
 
     systemd.services.buildbot-master = {
-      after = [ "postgresql.target" ];
+      after = [ "postgresql.target" ] ++ lib.optional (cfg.authBackend == "oidc") "network-online.target";
+      wants = lib.optional (cfg.authBackend == "oidc") "network-online.target";
       path = [
         pkgs.openssl
         pkgs.openssh


### PR DESCRIPTION
Small change after #528. Buildbot will need a network connection to fetch the oauth url 99% of the time when using a custom oauth provider