### PR TITLE
Fix Twisted epoll ENOENT race condition causing HTTP 502 errors

### DIFF
--- a/nixosModules/packages.nix
+++ b/nixosModules/packages.nix
@@ -6,27 +6,29 @@
 }:
 let
   cfg = config.services.buildbot-nix.packages;
+  # Use our patched buildbot packages scope which includes patched twisted
+  buildbotPackages = pkgs.callPackage ../packages/buildbot-packages.nix { };
 in
 {
   options.services.buildbot-nix.packages = {
     python = lib.mkOption {
       type = lib.types.package;
-      default = config.services.buildbot-nix.packages.buildbot.python;
-      defaultText = lib.literalExpression "config.services.buildbot-nix.packages.buildbot.python";
+      default = buildbotPackages.python;
+      defaultText = lib.literalExpression "buildbotPackages.python";
       description = "Python interpreter to use for buildbot-nix.";
     };
 
     buildbot = lib.mkOption {
       type = lib.types.package;
-      default = pkgs.callPackage ../packages/buildbot.nix { };
-      defaultText = lib.literalExpression "pkgs.callPackage ../packages/buildbot.nix { }";
+      default = buildbotPackages.buildbot;
+      defaultText = lib.literalExpression "buildbotPackages.buildbot";
       description = "The buildbot package to use.";
     };
 
     buildbot-worker = lib.mkOption {
       type = lib.types.package;
-      default = pkgs.buildbot-worker;
-      defaultText = lib.literalExpression "pkgs.buildbot-worker";
+      default = buildbotPackages.buildbot-worker;
+      defaultText = lib.literalExpression "buildbotPackages.buildbot-worker";
       description = "The buildbot-worker package to use.";
     };
 
@@ -41,8 +43,8 @@ in
 
     buildbot-plugins = lib.mkOption {
       type = lib.types.attrsOf lib.types.package;
-      default = pkgs.buildbot-plugins;
-      defaultText = lib.literalExpression "pkgs.buildbot-plugins";
+      default = buildbotPackages.buildbot-plugins;
+      defaultText = lib.literalExpression "buildbotPackages.buildbot-plugins";
       description = "Attrset of buildbot plugin packages to use.";
     };
 

--- a/packages/buildbot-packages.nix
+++ b/packages/buildbot-packages.nix
@@ -1,0 +1,33 @@
+{
+  pkgs,
+  lib,
+  newScope,
+}:
+let
+  # Patch twisted to handle ENOENT in epoll reactor when fd is closed before registration.
+  # This fixes HTTP 502 errors caused by a race condition where a connection is accepted
+  # but reset by the peer before the reactor can register it with epoll.
+  python3 = pkgs.python3.override {
+    packageOverrides = final: prev: {
+      twisted = prev.twisted.overrideAttrs (old: {
+        patches = (old.patches or [ ]) ++ [ ../patches/twisted-epoll-enoent.patch ];
+      });
+    };
+  };
+in
+lib.makeScope (self: newScope (self.python.pkgs // self)) (self: {
+  python = python3;
+  buildbot-pkg =
+    self.callPackage "${pkgs.path}/pkgs/development/tools/continuous-integration/buildbot/pkg.nix"
+      { };
+  buildbot-worker =
+    self.callPackage "${pkgs.path}/pkgs/development/tools/continuous-integration/buildbot/worker.nix"
+      { };
+  buildbot =
+    self.callPackage "${pkgs.path}/pkgs/development/tools/continuous-integration/buildbot/master.nix"
+      { };
+  buildbot-plugins = lib.recurseIntoAttrs (
+    self.callPackage "${pkgs.path}/pkgs/development/tools/continuous-integration/buildbot/plugins.nix"
+      { }
+  );
+})

--- a/packages/buildbot.nix
+++ b/packages/buildbot.nix
@@ -1,1 +1,5 @@
-{ buildbot, fetchpatch }: buildbot
+{ pkgs }:
+let
+  buildbotPackages = pkgs.callPackage ./buildbot-packages.nix { };
+in
+buildbotPackages.buildbot

--- a/patches/twisted-epoll-enoent.patch
+++ b/patches/twisted-epoll-enoent.patch
@@ -1,0 +1,62 @@
+diff --git a/src/twisted/internet/epollreactor.py b/src/twisted/internet/epollreactor.py
+index c13e50be01..311cfed5d6 100644
+--- a/src/twisted/internet/epollreactor.py
++++ b/src/twisted/internet/epollreactor.py
+@@ -17,6 +17,7 @@ import select
+ from zope.interface import implementer
+ 
+ from twisted.internet import posixbase
++from twisted.internet.main import CONNECTION_LOST
+ from twisted.internet.interfaces import IReactorFDSet
+ from twisted.python import log
+ 
+@@ -109,6 +110,32 @@ class EPollReactor(posixbase.PosixReactorBase, posixbase._PollLikeMixin):
+             primary.add(fd)
+             selectables[fd] = xer
+ 
++    def _handleENOENT(self, selectable):
++        """
++        Handle ENOENT error from epoll_ctl.
++
++        This can happen when a connection is accepted but reset by the peer
++        before we finish registering it with epoll. Clean up tracking state
++        and schedule connectionLost to notify the protocol.
++
++        @param selectable: The FileDescriptor that could not be registered.
++        """
++        fd = selectable.fileno()
++        # Clean up any stale tracking state for this fd
++        self._reads.discard(fd)
++        self._writes.discard(fd)
++        self._selectables.pop(fd, None)
++
++        # Schedule connectionLost to properly clean up the connection
++
++        self.callLater(
++            0,
++            log.callWithLogger,
++            selectable,
++            selectable.connectionLost,
++            CONNECTION_LOST,
++        )
++
+     def addReader(self, reader):
+         """
+         Add a FileDescriptor for notification of data available to read.
+@@ -123,6 +150,8 @@ class EPollReactor(posixbase.PosixReactorBase, posixbase._PollLikeMixin):
+                 # e.g. filesystem files, so for those we just poll
+                 # continuously:
+                 self._continuousPolling.addReader(reader)
++            elif e.errno == errno.ENOENT:
++                self._handleENOENT(reader)
+             else:
+                 raise
+ 
+@@ -140,6 +169,8 @@ class EPollReactor(posixbase.PosixReactorBase, posixbase._PollLikeMixin):
+                 # e.g. filesystem files, so for those we just poll
+                 # continuously:
+                 self._continuousPolling.addWriter(writer)
++            elif e.errno == errno.ENOENT:
++                self._handleENOENT(writer)
+             else:
+                 raise


### PR DESCRIPTION
When a TCP connection is accepted but immediately reset by the peer before the reactor can register it with epoll, epoll_ctl returns ENOENT. Previously this caused an unhandled FileNotFoundError that would propagate up and cause HTTP 502 errors in web applications.

This patch handles ENOENT in addReader/addWriter by:
1. Cleaning up any stale tracking state for the fd
2. Scheduling connectionLost to properly notify the protocol

This race condition commonly occurs in high-traffic scenarios where a reverse proxy (like nginx) connects to an upstream server but the connection is reset before the server finishes setting it up.