### PR TITLE
webhooks: update existing hooks to sync secret on reload

### DIFF
--- a/buildbot_nix/buildbot_nix/gitea_projects.py
+++ b/buildbot_nix/buildbot_nix/gitea_projects.py
@@ -325,7 +325,16 @@ def create_repo_hook(config: RepoHookConfig) -> None:
     }
     for hook in hooks:
         if hook["config"]["url"] == config.instance_url + "change_hook/gitea":
-            log.msg(f"hook for {config.owner}/{config.repo} already exists")
+            # Always update the hook to ensure the secret stays in sync
+            # (Gitea doesn't expose secrets via API, so we can't detect changes)
+            hook_id = hook["id"]
+            log.msg(f"updating existing hook for {config.owner}/{config.repo}")
+            http_request(
+                f"{config.gitea_url}/api/v1/repos/{config.owner}/{config.repo}/hooks/{hook_id}",
+                method="PATCH",
+                headers=headers,
+                data=data,
+            )
             return
 
     log.msg(f"creating hook for {config.owner}/{config.repo}")

--- a/buildbot_nix/buildbot_nix/github_projects.py
+++ b/buildbot_nix/buildbot_nix/github_projects.py
@@ -690,7 +690,16 @@ def create_project_hook(
     }
     for hook in hooks:
         if hook["config"]["url"] == webhook_url + "change_hook/github":
-            log.msg(f"hook for {owner}/{repo} already exists")
+            # Always update the hook to ensure the secret stays in sync
+            # (GitHub doesn't expose secrets via API, so we can't detect changes)
+            hook_id = hook["id"]
+            log.msg(f"updating existing hook for {owner}/{repo}")
+            http_request(
+                f"https://api.github.com/repos/{owner}/{repo}/hooks/{hook_id}",
+                method="PATCH",
+                headers=headers,
+                data=data,
+            )
             return
 
     http_request(


### PR DESCRIPTION
GitHub and Gitea do not expose webhook secrets via their APIs, making it impossible to detect when the local webhookSecretFile has been rotated. Previously, buildbot-nix would skip hook creation if a hook with matching URL already existed, leaving stale secrets in place and causing webhook signature verification failures.

Use PATCH to update existing hooks instead of returning early. This ensures the webhook configuration (including the secret) stays in sync whenever the reload builder runs.