### PR TITLE
nix_eval: accept null output paths for impure derivations

### DIFF
--- a/buildbot_nix/buildbot_nix/models.py
+++ b/buildbot_nix/buildbot_nix/models.py
@@ -430,7 +430,12 @@ class NixEvalJobSuccess(BaseModel):
     drvPath: str  # noqa: N815
     inputDrvs: dict[str, list[str]] | None = None  # noqa: N815
     name: str
-    outputs: dict[str, str]
+    # nix-eval-jobs emits null output paths for impure and some
+    # content-addressed derivations: it cannot know their store paths
+    # without actually building them. Accept None so the whole eval step
+    # does not crash; downstream consumers already treat a missing
+    # out path as "not statically known" via `job.outputs["out"] or None`.
+    outputs: dict[str, str | None]
     system: str
 
 

--- a/buildbot_nix/buildbot_nix/tests/test_nix_eval_job.py
+++ b/buildbot_nix/buildbot_nix/tests/test_nix_eval_job.py
@@ -1,0 +1,33 @@
+"""Regression tests for NixEvalJob parsing."""
+
+from __future__ import annotations
+
+from buildbot_nix.models import NixEvalJobModel, NixEvalJobSuccess
+
+
+def test_impure_job_with_null_out_parses() -> None:
+    """nix-eval-jobs emits outputs with null values for impure / CA
+    derivations that have no statically-known output path. We must accept
+    such jobs instead of crashing the entire eval step.
+
+    See: https://buildbot.thalheim.io/api/v2/logs/671634/raw_inline
+    """
+    raw = {
+        "attr": "aarch64-linux.pytest-impure",
+        "attrPath": ["checks", "aarch64-linux", "pytest-impure"],
+        "cacheStatus": "notBuilt",
+        "neededBuilds": [],
+        "neededSubstitutes": [],
+        "drvPath": "/nix/store/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-pytest-impure.drv",
+        "inputDrvs": {},
+        "name": "pytest-impure",
+        "outputs": {"out": None},
+        "system": "aarch64-linux",
+    }
+
+    job = NixEvalJobModel.validate_python(raw)
+
+    assert isinstance(job, NixEvalJobSuccess)
+    assert job.outputs == {"out": None}
+    # Downstream code does `job.outputs["out"] or None`; ensure that still works.
+    assert (job.outputs["out"] or None) is None


### PR DESCRIPTION
nix-eval-jobs cannot compute a static output path for impure or content-addressed derivations -- doing so would require actually building them. In that case it emits the job with output values set to JSON null, e.g.:

    {"attr": "aarch64-linux.pytest-impure",
     "outputs": {"out": null}, ...}
