### PR TITLE
drop hercules-ci-effects flake input

### DIFF
--- a/checks/scheduled-effects.nix
+++ b/checks/scheduled-effects.nix
@@ -120,7 +120,7 @@
             git config user.name 'Test User'
             git config user.email 'test@example.com'
 
-            git add flake.nix flake.lock
+            git add flake.nix flake.lock effects-lib.nix
             git commit -m "Initial commit with scheduled effects"
 
             # Push to bare repository

--- a/checks/test-flake/effects-lib.nix
+++ b/checks/test-flake/effects-lib.nix
@@ -1,0 +1,51 @@
+# Minimal subset of hercules-ci-effects sufficient for buildbot-effects.
+# Avoids pulling hercules-ci-effects (and its transitive flake-parts input)
+# into every consumer of this flake.
+{ pkgs }:
+{
+  mkEffect =
+    {
+      effectScript ? "",
+      userSetupScript ? "",
+      name ? "effect",
+      inputs ? [ ],
+      secretsMap ? { },
+    }:
+    pkgs.stdenvNoCC.mkDerivation {
+      inherit name effectScript userSetupScript;
+      isEffect = true;
+      secretsMap = builtins.toJSON secretsMap;
+      nativeBuildInputs = [
+        pkgs.cacert
+        pkgs.curl
+        pkgs.jq
+      ]
+      ++ inputs;
+      phases = [
+        "initPhase"
+        "userSetupPhase"
+        "effectPhase"
+      ];
+      initPhase = ''
+        exec </dev/null
+        export HOME=/build/home
+        mkdir -p "$HOME"
+      '';
+      userSetupPhase = ''eval "$userSetupScript"'';
+      effectPhase = ''eval "$effectScript"'';
+    };
+
+  # When the condition is false we still want eval/build of the effect's
+  # closure to succeed, so return a no-op effect instead.
+  runIf =
+    condition: effect:
+    if condition then
+      { run = effect; }
+    else
+      {
+        dependencies = effect.inputDerivation // {
+          isEffect = false;
+          buildDependenciesOnly = true;
+        };
+      };
+}

--- a/checks/test-flake/flake.lock
+++ b/checks/test-flake/flake.lock
@@ -1,61 +1,6 @@
 {
   "nodes": {
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "hercules-ci-effects",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
-        "type": "github"
-      },
-      "original": {
-        "id": "flake-parts",
-        "type": "indirect"
-      }
-    },
-    "hercules-ci-effects": {
-      "inputs": {
-        "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1776603440,
-        "narHash": "sha256-wA+ONiwbvQIy7ERJx/ruhV7y5xku6XKstXCII5bIbdI=",
-        "owner": "hercules-ci",
-        "repo": "hercules-ci-effects",
-        "rev": "e2456ee419f9d75f8382e3d6c5af4690b316a5a8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "hercules-ci-effects",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
-      "locked": {
-        "lastModified": 1775710090,
-        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
       "locked": {
         "lastModified": 1776877367,
         "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
@@ -73,8 +18,7 @@
     },
     "root": {
       "inputs": {
-        "hercules-ci-effects": "hercules-ci-effects",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/checks/test-flake/flake.nix
+++ b/checks/test-flake/flake.nix
@@ -1,14 +1,12 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    hercules-ci-effects.url = "github:hercules-ci/hercules-ci-effects";
   };
 
   outputs =
     {
       self,
       nixpkgs,
-      hercules-ci-effects,
     }:
     let
       systems = [
@@ -31,7 +29,7 @@
         args:
         let
           pkgs = nixpkgs.legacyPackages.x86_64-linux;
-          hci-effects = hercules-ci-effects.lib.withPkgs pkgs;
+          hci-effects = import ./effects-lib.nix { inherit pkgs; };
         in
         {
           onPush.default.outputs.effects = { };

--- a/flake.lock
+++ b/flake.lock
@@ -1,46 +1,5 @@
 {
   "nodes": {
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "hercules-ci-effects",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
-        "type": "github"
-      },
-      "original": {
-        "id": "flake-parts",
-        "type": "indirect"
-      }
-    },
-    "hercules-ci-effects": {
-      "inputs": {
-        "flake-parts": "flake-parts",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776603440,
-        "narHash": "sha256-wA+ONiwbvQIy7ERJx/ruhV7y5xku6XKstXCII5bIbdI=",
-        "owner": "hercules-ci",
-        "repo": "hercules-ci-effects",
-        "rev": "e2456ee419f9d75f8382e3d6c5af4690b316a5a8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "hercules-ci-effects",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1777143883,
@@ -60,7 +19,6 @@
     },
     "root": {
       "inputs": {
-        "hercules-ci-effects": "hercules-ci-effects",
         "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -8,9 +8,6 @@
     # used for development
     treefmt-nix.url = "github:numtide/treefmt-nix";
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
-
-    hercules-ci-effects.url = "github:hercules-ci/hercules-ci-effects";
-    hercules-ci-effects.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs =
@@ -18,7 +15,6 @@
       self,
       nixpkgs,
       treefmt-nix,
-      hercules-ci-effects,
       ...
     }:
     let
@@ -75,7 +71,7 @@
       );
 
       herculesCI = import ./herculesCI {
-        inherit self hercules-ci-effects;
+        inherit self;
         pkgs = nixpkgs.legacyPackages.x86_64-linux;
       };
     };

--- a/herculesCI/default.nix
+++ b/herculesCI/default.nix
@@ -1,11 +1,10 @@
 {
   self,
   pkgs,
-  hercules-ci-effects,
   ...
 }:
 let
-  hci-effects = hercules-ci-effects.lib.withPkgs pkgs;
+  hci-effects = import ./effects-lib.nix { inherit pkgs; };
 in
 { primaryRepo, ... }:
 {

--- a/herculesCI/effects-lib.nix
+++ b/herculesCI/effects-lib.nix
@@ -1,0 +1,51 @@
+# Minimal subset of hercules-ci-effects sufficient for buildbot-effects.
+# Avoids pulling hercules-ci-effects (and its transitive flake-parts input)
+# into every consumer of this flake.
+{ pkgs }:
+{
+  mkEffect =
+    {
+      effectScript ? "",
+      userSetupScript ? "",
+      name ? "effect",
+      inputs ? [ ],
+      secretsMap ? { },
+    }:
+    pkgs.stdenvNoCC.mkDerivation {
+      inherit name effectScript userSetupScript;
+      isEffect = true;
+      secretsMap = builtins.toJSON secretsMap;
+      nativeBuildInputs = [
+        pkgs.cacert
+        pkgs.curl
+        pkgs.jq
+      ]
+      ++ inputs;
+      phases = [
+        "initPhase"
+        "userSetupPhase"
+        "effectPhase"
+      ];
+      initPhase = ''
+        exec </dev/null
+        export HOME=/build/home
+        mkdir -p "$HOME"
+      '';
+      userSetupPhase = ''eval "$userSetupScript"'';
+      effectPhase = ''eval "$effectScript"'';
+    };
+
+  # When the condition is false we still want eval/build of the effect's
+  # closure to succeed, so return a no-op effect instead.
+  runIf =
+    condition: effect:
+    if condition then
+      { run = effect; }
+    else
+      {
+        dependencies = effect.inputDerivation // {
+          isEffect = false;
+          buildDependenciesOnly = true;
+        };
+      };
+}


### PR DESCRIPTION
The dependency pulled in flake-parts and a second nixpkgs lock for every downstream consumer even though we only used mkEffect and runIf. Vendor a minimal compatible implementation in herculesCI/effects-lib.nix and reuse a copy in checks/test-flake so the test fixture stays self-contained and evaluates without network access to extra inputs.