### PR TITLE
Use merge queue scheduler for gitea-mq

### DIFF
--- a/buildbot_nix/buildbot_nix/project_config.py
+++ b/buildbot_nix/buildbot_nix/project_config.py
@@ -86,7 +86,7 @@ def config_for_project(
                 change_filter=util.ChangeFilter(
                     # TODO add filter
                     repository=project.url,
-                    branch_re="(gh-readonly-queue/.*|staging|trying)",
+                    branch_re="(gh-readonly-queue/.*|gitea-mq/.*|staging|trying)",
                 ),
                 builderNames=[f"{project.name}/nix-eval"],
             ),


### PR DESCRIPTION
Without this two Gitea merge queue branches created at the same time will get ignored due to the tree stable timer as part of the primary scheduler

Draft as untested :)